### PR TITLE
(QENG-3275) Add support for 32-bit puppet on 64-bit windows

### DIFF
--- a/lib/beaker-hostgenerator/cli.rb
+++ b/lib/beaker-hostgenerator/cli.rb
@@ -101,6 +101,12 @@ Usage: beaker-hostgenerator [options] <layout>
 
       puts "\n"
 
+      puts "valid beaker-hostgenerator architectures:"
+      puts "   32   => 32-bit OS"
+      puts "   64   => 64-bit OS"
+      puts "   6432 => 64-bit OS with 32-bit Puppet (Windows Only)"
+      puts "\n"
+
       roles = BeakerHostGenerator::Utils.get_roles
       puts "valid beaker-hostgenerator host roles:  "
       roles.each do |k,v|

--- a/lib/beaker-hostgenerator/data/vmpooler.rb
+++ b/lib/beaker-hostgenerator/data/vmpooler.rb
@@ -284,6 +284,11 @@ module BeakerHostGenerator
           'template' => 'win-2003-x86_64',
           'ruby_arch' => 'x64'
         },
+        'windows2003-6432' => {
+          'platform' => 'windows-2003-64',
+          'template' => 'win-2003-x86_64',
+          'ruby_arch' => 'x86'
+        },
         'windows2003r2-32' => {
           'platform' => 'windows-2003r2-32',
           'template' => 'win-2003r2-i386',
@@ -294,25 +299,50 @@ module BeakerHostGenerator
           'template' => 'win-2003r2-x86_64',
           'ruby_arch' => 'x64'
         },
+        'windows2003r2-6432' => {
+          'platform' => 'windows-2003r2-64',
+          'template' => 'win-2003r2-x86_64',
+          'ruby_arch' => 'x86'
+        },
         'windows2008-64' => {
           'platform' => 'windows-2008-64',
           'template' => 'win-2008-x86_64',
           'ruby_arch' => 'x64'
+        },
+        'windows2008-6432' => {
+          'platform' => 'windows-2008-64',
+          'template' => 'win-2008-x86_64',
+          'ruby_arch' => 'x86'
         },
         'windows2008r2-64' => {
           'platform' => 'windows-2008r2-64',
           'template' => 'win-2008r2-x86_64',
           'ruby_arch' => 'x64'
         },
+        'windows2008r2-6432' => {
+          'platform' => 'windows-2008r2-64',
+          'template' => 'win-2008r2-x86_64',
+          'ruby_arch' => 'x86'
+        },
         'windows2012-64' => {
           'platform' => 'windows-2012-64',
           'template' => 'win-2012-x86_64',
           'ruby_arch' => 'x64'
         },
+        'windows2012-6432' => {
+          'platform' => 'windows-2012-64',
+          'template' => 'win-2012-x86_64',
+          'ruby_arch' => 'x86'
+        },
         'windows2012r2-64' => {
           'platform' => 'windows-2012r2-64',
           'template' => 'win-2012r2-x86_64',
           'ruby_arch' => 'x64'
+        },
+        'windows2012r2-6432' => {
+          'platform' => 'windows-2012r2-64',
+          'template' => 'win-2012r2-x86_64',
+          'ruby_arch' => 'x86'
         },
         'windows7-64' => {
           'platform' => 'windows-7-64',

--- a/lib/beaker-hostgenerator/data/vmpooler.rb
+++ b/lib/beaker-hostgenerator/data/vmpooler.rb
@@ -281,59 +281,73 @@ module BeakerHostGenerator
         },
         'windows2003-64' => {
           'platform' => 'windows-2003-64',
-          'template' => 'win-2003-x86_64'
+          'template' => 'win-2003-x86_64',
+          'ruby_arch' => 'x64'
         },
         'windows2003r2-32' => {
           'platform' => 'windows-2003r2-32',
-          'template' => 'win-2003r2-i386'
+          'template' => 'win-2003r2-i386',
+          'ruby_arch' => 'x86'
         },
         'windows2003r2-64' => {
           'platform' => 'windows-2003r2-64',
           'template' => 'win-2003r2-x86_64',
+          'ruby_arch' => 'x64'
         },
         'windows2008-64' => {
           'platform' => 'windows-2008-64',
-          'template' => 'win-2008-x86_64'
+          'template' => 'win-2008-x86_64',
+          'ruby_arch' => 'x64'
         },
         'windows2008r2-64' => {
           'platform' => 'windows-2008r2-64',
-          'template' => 'win-2008r2-x86_64'
+          'template' => 'win-2008r2-x86_64',
+          'ruby_arch' => 'x64'
         },
         'windows2012-64' => {
           'platform' => 'windows-2012-64',
-          'template' => 'win-2012-x86_64'
+          'template' => 'win-2012-x86_64',
+          'ruby_arch' => 'x64'
         },
         'windows2012r2-64' => {
           'platform' => 'windows-2012r2-64',
-          'template' => 'win-2012r2-x86_64'
+          'template' => 'win-2012r2-x86_64',
+          'ruby_arch' => 'x64'
         },
         'windows7-64' => {
           'platform' => 'windows-7-64',
-          'template' => 'win-7-x86_64'
+          'template' => 'win-7-x86_64',
+          'ruby_arch' => 'x64'
         },
         'windows8-64' => {
           'platform' => 'windows-8-64',
-          'template' => 'win-8-x86_64'
+          'template' => 'win-8-x86_64',
+          'ruby_arch' => 'x64'
         },
         'windows81-64' => {
           'platform' => 'windows-8.1-64',
-          'template' => 'win-81-x86_64'
+          'template' => 'win-81-x86_64',
+          'ruby_arch' => 'x64'
         },
         'windowsvista-64' => {
           'platform' => 'windows-vista-64',
-          'template' => 'win-vista-x86_64'
+          'template' => 'win-vista-x86_64',
+          'ruby_arch' => 'x64'
         },
         'windows10ent-32' => {
           'platform' => 'windows-10ent-32',
-          'template' => 'win-10-ent-i386'
+          'template' => 'win-10-ent-i386',
+          'ruby_arch' => 'x86'
         },
         'windows10ent-64' => {
           'platform' => 'windows-10ent-x86_64',
-          'template' => 'win-10-ent-x86_64'
+          'template' => 'win-10-ent-x86_64',
+          'ruby_arch' => 'x64'
         },
         'windows10pro-64' => {
           'platform' => 'windows-10pro-x86_64',
-          'template' => 'win-10-pro-x86_64'
+          'template' => 'win-10-pro-x86_64',
+          'ruby_arch' => 'x64'
         },
       }
 

--- a/lib/beaker-hostgenerator/generator.rb
+++ b/lib/beaker-hostgenerator/generator.rb
@@ -59,6 +59,7 @@ module BeakerHostGenerator
         host_name, host_config = generate_node(node_info, BASE_HOST_CONFIG)
 
         if PE_USE_WIN32 && ostype =~ /windows/ && node_info['bits'] == "64"
+          host_config['ruby_arch'] = 'x86'
           host_config['install_32'] = true
         end
 


### PR DESCRIPTION
This PR ensures `ruby_arch` defaults to the correct value based on the Windows OS architecture as the setting is required to run puppet, facter and pxp-agent acceptance on Windows hosts, and allows the caller to request 32-bit Puppet on 64-bit Windows, e.g. `windows2012r2-6432a`. Windows is unique in that there are three combinations, and we currently support all three:

* 32-bit Puppet on 32-bit Windows
* 32-bit Puppet on 64-bit Windows
* 64-bit Puppet on 64-bit Windows