### PR TITLE
Revert "(QENG-3309) Add support for Cisco wrlinux-7"

### DIFF
--- a/lib/beaker-hostgenerator/data/vmpooler.rb
+++ b/lib/beaker-hostgenerator/data/vmpooler.rb
@@ -7,10 +7,6 @@ module BeakerHostGenerator
           'platform' => 'eos-4-i386',
           'template' => 'arista-4-i386'
         },
-        'cisco7-64' => {
-          'platform' => 'cisco-wrlinux-7-x86_64',
-          'template' => 'cisco-exr-9k-x86_64'
-        },
         'centos4-32' => {
           'platform' => 'el-4-i386',
           'template' => 'centos-4-i386'


### PR DESCRIPTION
This reverts commit 3e36da18e7bfeec2fa92295fa5f9959d45611eb4.

I didn't notice until working on another ticket that this has a mismatched template platform value.