### PR TITLE
(QENG-3309) (QENG-3309) Add cisco vmpooler platforms.

### DIFF
--- a/lib/beaker-hostgenerator/data/vmpooler.rb
+++ b/lib/beaker-hostgenerator/data/vmpooler.rb
@@ -35,6 +35,18 @@ module BeakerHostGenerator
           'platform' => 'el-7-x86_64',
           'template' => 'centos-7-x86_64'
         },
+        'cisco5-64' => {
+          'platform' => 'ciscowrlinux-5-x86_64',
+          'template' => 'cisco-wrlinux-5-x86_64',
+        },
+        'cisco7-64' => {
+          'platform' => 'ciscowrlinux-7-x86_64',
+          'template' => 'cisco-wrlinux-7-x86_64',
+        },
+        'cisco9-64' => {
+          'platform' => 'ciscoexr-9-x86_64',
+          'template' => 'cisco-exr-9k-x86_64',
+        },
         'debian6-32' => {
           'platform' => 'debian-6-i386',
           'template' => 'debian-6-i386'


### PR DESCRIPTION
This also adds `cisco-exr-9k-x86_64` but I wasn't able to find a QENG ticket for that.

@LuvCurves This redoes #11 which had mismatched platform and template values. Would you mind reviewing this PR and letting me know if this will suit your needs?

@joshcooper @justinstoller @sschneid please review when you get a chance.