### PR TITLE
(maint) Add better support for Cisco platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ Versioning](http://semver.org).
 ### Changed
 - Updated this changelog for recent beaker-hostgenerator releases.
 
+## [0.2.1] - 2016-01-20
+- Fix platforms:
+  - Cisco NXOS 5 (x86_64)
+    - set Virtual Routing & Forwarding (vrf) to 'management'
+    - set ssh username to 'beaker'
+  - Cisco eXR 7 (x86_64)
+    - set Virtual Routing & Forwarding (vrf) to 'management'
+  
 ## [0.2.0] - 2015-12-22
 - Add platforms:
   - Cumulus 2.5 (x86_64)

--- a/lib/beaker-hostgenerator/data/vmpooler.rb
+++ b/lib/beaker-hostgenerator/data/vmpooler.rb
@@ -37,11 +37,16 @@ module BeakerHostGenerator
         },
         'cisconxos5-64' => {
           'platform' => 'cisco-5-x86_64',
-          'template' => 'cisco-nxos-9k-x86_64'
+          'template' => 'cisco-nxos-9k-x86_64',
+          'vrf' => 'management',
+          'ssh' => {
+            'user' => 'beaker'
+          }
         },
         'ciscoexr7-64' => {
           'platform' => 'cisco-7-x86_64',
-          'template' => 'cisco-exr-9k-x86_64'
+          'template' => 'cisco-exr-9k-x86_64',
+          'vrf' => 'management'
         },
         'cumulus25-64' => {
           'platform' => 'cumulus-2.5-x86_64',


### PR DESCRIPTION
Need support for Cisco Virtrual Routing & Forwarding (VRF) as well as to use 'beaker' as the ssh username for Cisco NXOS