### PR TITLE
(maint) Update Windows 10 platform names

### DIFF
--- a/lib/beaker-hostgenerator/data/vmpooler.rb
+++ b/lib/beaker-hostgenerator/data/vmpooler.rb
@@ -386,12 +386,12 @@ module BeakerHostGenerator
           'ruby_arch' => 'x86'
         },
         'windows10ent-64' => {
-          'platform' => 'windows-10ent-x86_64',
+          'platform' => 'windows-10ent-64',
           'template' => 'win-10-ent-x86_64',
           'ruby_arch' => 'x64'
         },
         'windows10pro-64' => {
-          'platform' => 'windows-10pro-x86_64',
+          'platform' => 'windows-10pro-64',
           'template' => 'win-10-pro-x86_64',
           'ruby_arch' => 'x64'
         },


### PR DESCRIPTION
 - Previous convention for Windows platforms is to always end in a -32
   or -64.  There are some tests that rely on this naming scheme to
   properly identify a 32-bit or 64-bit OS.

   For instance, a Puppet acceptance test relies on that convention when
   detecting the location of binaries per:

   https://github.com/puppetlabs/puppet/blob/master/acceptance/tests/ensure_puppet-agent_paths.rb#L140-L143

   Original commit that introduced these was
   3d1be3833b0dd95d508d89ecbe76464524f578c3