### PR TITLE
(QENG-3489) Add Ubuntu 16.04 to beaker host generator data.

### DIFF
--- a/lib/beaker-hostgenerator/data/vmpooler.rb
+++ b/lib/beaker-hostgenerator/data/vmpooler.rb
@@ -299,6 +299,14 @@ module BeakerHostGenerator
           'platform' => 'ubuntu-15.10-amd64',
           'template' => 'ubuntu-1510-x86_64'
         },
+        'ubuntu1604-32' => {
+          'platform' => 'ubuntu-16.04-i386',
+          'template' => 'ubuntu-1604-i386'
+        },
+        'ubuntu1604-64' => {
+          'platform' => 'ubuntu-16.04-amd64',
+          'template' => 'ubuntu-1604-x86_64'
+        },
         'windows2003-64' => {
           'platform' => 'windows-2003-64',
           'template' => 'win-2003-x86_64',

--- a/test/fixtures/default/cisconx-64a
+++ b/test/fixtures/default/cisconx-64a
@@ -1,15 +1,15 @@
 ---
-arguments_string: "--osinfo-version 0 cisconxos5-64a"
+arguments_string: cisconx-64a
 environment_variables: {}
 expected_hash:
   HOSTS:
-    cisconxos5-64-1:
+    cisconx-64-1:
       pe_dir: 
       pe_ver: 
       pe_upgrade_dir: 
       pe_upgrade_ver: 
       hypervisor: vmpooler
-      platform: cisco-5-x86_64
+      platform: cisco_nexus-7-x86_64
       template: cisco-nxos-9k-x86_64
       vrf: management
       ssh:

--- a/test/fixtures/default/ciscoxr-64u
+++ b/test/fixtures/default/ciscoxr-64u
@@ -1,17 +1,16 @@
 ---
-arguments_string: "--osinfo-version 0 ciscoexr7-64u"
+arguments_string: ciscoxr-64u
 environment_variables: {}
 expected_hash:
   HOSTS:
-    ciscoexr7-64-1:
+    ciscoxr-64-1:
       pe_dir: 
       pe_ver: 
       pe_upgrade_dir: 
       pe_upgrade_ver: 
       hypervisor: vmpooler
-      platform: cisco-7-x86_64
+      platform: cisco_ios_xr-6-x86_64
       template: cisco-exr-9k-x86_64
-      vrf: management
       roles:
       - agent
       - ca

--- a/test/fixtures/default/ubuntu1604-32u
+++ b/test/fixtures/default/ubuntu1604-32u
@@ -1,0 +1,21 @@
+---
+arguments_string: ubuntu1604-32u
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    ubuntu1604-32-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      hypervisor: vmpooler
+      platform: ubuntu-16.04-i386
+      template: ubuntu-1604-i386
+      roles:
+      - agent
+      - ca
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception: 

--- a/test/fixtures/default/ubuntu1604-64l
+++ b/test/fixtures/default/ubuntu1604-64l
@@ -1,0 +1,21 @@
+---
+arguments_string: ubuntu1604-64l
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    ubuntu1604-64-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      hypervisor: vmpooler
+      platform: ubuntu-16.04-amd64
+      template: ubuntu-1604-x86_64
+      roles:
+      - agent
+      - classifier
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception: 

--- a/test/fixtures/osinfo-version-0/cisconx-64a
+++ b/test/fixtures/osinfo-version-0/cisconx-64a
@@ -1,20 +1,21 @@
 ---
-arguments_string: ciscoexr7-64u
+arguments_string: "--osinfo-version 0 cisconx-64a"
 environment_variables: {}
 expected_hash:
   HOSTS:
-    ciscoexr7-64-1:
+    cisconx-64-1:
       pe_dir: 
       pe_ver: 
       pe_upgrade_dir: 
       pe_upgrade_ver: 
       hypervisor: vmpooler
-      platform: cisco-7-x86_64
-      template: cisco-exr-9k-x86_64
+      platform: cisco_nexus-7-x86_64
+      template: cisco-nxos-9k-x86_64
       vrf: management
+      ssh:
+        user: beaker
       roles:
       - agent
-      - ca
   CONFIG:
     nfs_server: none
     consoleport: 443

--- a/test/fixtures/osinfo-version-0/ciscoxr-64u
+++ b/test/fixtures/osinfo-version-0/ciscoxr-64u
@@ -1,21 +1,19 @@
 ---
-arguments_string: "--osinfo-version 1 cisconxos5-64a"
+arguments_string: "--osinfo-version 0 ciscoxr-64u"
 environment_variables: {}
 expected_hash:
   HOSTS:
-    cisconxos5-64-1:
+    ciscoxr-64-1:
       pe_dir: 
       pe_ver: 
       pe_upgrade_dir: 
       pe_upgrade_ver: 
       hypervisor: vmpooler
-      platform: cisco-5-x86_64
-      template: cisco-nxos-9k-x86_64
-      vrf: management
-      ssh:
-        user: beaker
+      platform: cisco_ios_xr-6-x86_64
+      template: cisco-exr-9k-x86_64
       roles:
       - agent
+      - ca
   CONFIG:
     nfs_server: none
     consoleport: 443

--- a/test/fixtures/osinfo-version-0/ubuntu1604-32u
+++ b/test/fixtures/osinfo-version-0/ubuntu1604-32u
@@ -1,0 +1,21 @@
+---
+arguments_string: "--osinfo-version 0 ubuntu1604-32u"
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    ubuntu1604-32-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      hypervisor: vmpooler
+      platform: ubuntu-16.04-i386
+      template: ubuntu-1604-i386
+      roles:
+      - agent
+      - ca
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception: 

--- a/test/fixtures/osinfo-version-0/ubuntu1604-64l
+++ b/test/fixtures/osinfo-version-0/ubuntu1604-64l
@@ -1,0 +1,21 @@
+---
+arguments_string: "--osinfo-version 0 ubuntu1604-64l"
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    ubuntu1604-64-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      hypervisor: vmpooler
+      platform: ubuntu-16.04-amd64
+      template: ubuntu-1604-x86_64
+      roles:
+      - agent
+      - classifier
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception: 

--- a/test/fixtures/osinfo-version-1/cisconx-64a
+++ b/test/fixtures/osinfo-version-1/cisconx-64a
@@ -1,20 +1,21 @@
 ---
-arguments_string: "--osinfo-version 1 ciscoexr7-64u"
+arguments_string: "--osinfo-version 1 cisconx-64a"
 environment_variables: {}
 expected_hash:
   HOSTS:
-    ciscoexr7-64-1:
+    cisconx-64-1:
       pe_dir: 
       pe_ver: 
       pe_upgrade_dir: 
       pe_upgrade_ver: 
       hypervisor: vmpooler
-      platform: cisco-7-x86_64
-      template: cisco-exr-9k-x86_64
+      platform: cisco_nexus-7-x86_64
+      template: cisco-nxos-9k-x86_64
       vrf: management
+      ssh:
+        user: beaker
       roles:
       - agent
-      - ca
   CONFIG:
     nfs_server: none
     consoleport: 443

--- a/test/fixtures/osinfo-version-1/ciscoxr-64u
+++ b/test/fixtures/osinfo-version-1/ciscoxr-64u
@@ -1,21 +1,19 @@
 ---
-arguments_string: cisconxos5-64a
+arguments_string: "--osinfo-version 1 ciscoxr-64u"
 environment_variables: {}
 expected_hash:
   HOSTS:
-    cisconxos5-64-1:
+    ciscoxr-64-1:
       pe_dir: 
       pe_ver: 
       pe_upgrade_dir: 
       pe_upgrade_ver: 
       hypervisor: vmpooler
-      platform: cisco-5-x86_64
-      template: cisco-nxos-9k-x86_64
-      vrf: management
-      ssh:
-        user: beaker
+      platform: cisco_ios_xr-6-x86_64
+      template: cisco-exr-9k-x86_64
       roles:
       - agent
+      - ca
   CONFIG:
     nfs_server: none
     consoleport: 443

--- a/test/fixtures/osinfo-version-1/ubuntu1604-32u
+++ b/test/fixtures/osinfo-version-1/ubuntu1604-32u
@@ -1,0 +1,21 @@
+---
+arguments_string: "--osinfo-version 1 ubuntu1604-32u"
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    ubuntu1604-32-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      hypervisor: vmpooler
+      platform: ubuntu-16.04-i386
+      template: ubuntu-1604-i386
+      roles:
+      - agent
+      - ca
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception: 

--- a/test/fixtures/osinfo-version-1/ubuntu1604-64l
+++ b/test/fixtures/osinfo-version-1/ubuntu1604-64l
@@ -1,0 +1,21 @@
+---
+arguments_string: "--osinfo-version 1 ubuntu1604-64l"
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    ubuntu1604-64-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      hypervisor: vmpooler
+      platform: ubuntu-16.04-amd64
+      template: ubuntu-1604-x86_64
+      roles:
+      - agent
+      - classifier
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception: 


### PR DESCRIPTION
This PR also
* fixes some test fixture borkage that resulted from the Cisco platform renames
* adds new test fixtures (it's not clear why these weren't in place previously)