### PR TITLE
(QENG-3276) Add None hypervisor and per-host settings support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Versioning](http://semver.org).
 ## [Unreleased][unreleased]
 ### Changed
 
+## [Next] - UNRELEASED
+- Add new 'none' hypervisor implementation to support static, non-provisioned hosts.
+- Add support for arbitrary, per-host key=value settings.
+
 ## [0.5.0] - 2016-03-30
 - Add platforms:
  - Ubuntu 16.06 x86 and x86_64

--- a/README.md
+++ b/README.md
@@ -3,18 +3,19 @@
 `beaker-hostgenerator` is a command line utility designed to generate beaker
 host config files using a compact command line SUT specification.
 
-It currently only supports puppetlabs' internal [vmpooler][vmpooler] templates,
-but is designed in a way that makes it possible to easily add support for
-additional hypervisor templates (any hypervisor type supported by
-[beaker][beaker]).
+It currently supports Puppets' internal [vmpooler][vmpooler] hypervisor and
+static (non-provisioned) nodes, and is designed in a way that makes it possible
+to easily add support for additional hypervisors (any hypervisor type supported
+by [beaker][beaker]).
 
 <!-- markdown-toc start - Don't edit this section. Run M-x markdown-toc-generate-toc again -->
 **Table of Contents**
 
 - [Beaker Host Generator](#beaker-host-generator)
     - [Usage](#usage)
-        - [Simple two-host SUT layout](#simple-two-host-sut-layout)
-        - [Single-host SUT layout with Arbitrary Roles](#single-host-sut-layout-with-arbitrary-roles)
+        - [Simple two-host layout](#simple-two-host-layout)
+        - [Single host with Arbitrary Roles](#single-host-with-arbitrary-roles)
+        - [Two hosts with multiple hypervisors and arbitrary host settings](#two-hosts-with-multiple-hypervisors-and-arbitrary-host-settings)
     - [Testing](#testing)
         - [Test Fixtures](#test-fixtures)
             - [Generated Fixtures](#generated-fixtures)
@@ -22,12 +23,12 @@ additional hypervisor templates (any hypervisor type supported by
     - [License](#license)
 
 <!-- markdown-toc end -->
- 
+
 ## Usage
 
 Below are some example usages of `beaker-hostgenerator`.
 
-### Simple two-host SUT layout
+### Simple two-host layout
 
 ```
 $ beaker-hostgenerator centos6-64mdca-32a
@@ -67,7 +68,7 @@ CONFIG:
   pooling_api: http://vmpooler.delivery.puppetlabs.net/
 ```
 
-### Single-host SUT layout with Arbitrary Roles
+### Single host with Arbitrary Roles
 
 ```
 $ beaker-hostgenerator centos6-32compile_master,another_role.ma
@@ -95,6 +96,44 @@ HOSTS:
       main:
         dns_alt_names: puppet
         environmentpath: "/etc/puppetlabs/puppet/environments"
+CONFIG:
+  nfs_server: none
+  consoleport: 443
+  pooling_api: http://vmpooler.delivery.puppetlabs.net/
+```
+
+### Two hosts with multiple hypervisors and arbitrary host settings
+
+```
+$ beaker-hostgenerator centos6-64m{hypervisor=none\,hostname=static-master}-redhat7-64a{somekey=some-value}
+```
+
+Will generate
+
+```yaml
+---
+HOSTS:
+  static-master:
+    pe_dir:
+    pe_ver:
+    pe_upgrade_dir:
+    pe_upgrade_ver:
+    platform: el-6-x86_64
+    hypervisor: none
+    roles:
+    - agent
+    - master
+  redhat7-64-1:
+    pe_dir:
+    pe_ver:
+    pe_upgrade_dir:
+    pe_upgrade_ver:
+    hypervisor: vmpooler
+    platform: el-7-x86_64
+    template: redhat-7-x86_64
+    somekey: some-value
+    roles:
+    - agent
 CONFIG:
   nfs_server: none
   consoleport: 443
@@ -179,7 +218,7 @@ There are a few circumstances when you should expect to run the
 
 ## Support
 
-Support offered by [Puppet Labs](https://puppetlabs.com) may not always be timely
+Support offered by [Puppet](https://puppet.com) may not always be timely
 since it is maintained by a tooling support team that is primarily focused on
 improving tools, infrastructure, and automation for our Enterprise products.
 

--- a/lib/beaker-hostgenerator/cli.rb
+++ b/lib/beaker-hostgenerator/cli.rb
@@ -1,5 +1,6 @@
 require 'beaker-hostgenerator/generator'
 require 'beaker-hostgenerator/hypervisor'
+require 'beaker-hostgenerator/roles'
 require 'optparse'
 
 module BeakerHostGenerator
@@ -169,7 +170,7 @@ eow
       puts "\n"
 
       puts "valid beaker-hostgenerator host roles:"
-      ROLES.each do |k,v|
+      BeakerHostGenerator::Roles::ROLES.each do |k,v|
         puts "   #{k} => #{v}"
       end
       puts "\n"

--- a/lib/beaker-hostgenerator/cli.rb
+++ b/lib/beaker-hostgenerator/cli.rb
@@ -126,8 +126,7 @@ Usage: beaker-hostgenerator [options] <layout>
         print_supported_values
         raise BeakerHostGenerator::Exceptions::SafeEarlyExit
       else
-        # Tokenizing the config definition for great justice
-        @tokens = tokenize_input(argv[0])
+        @layout = argv[0]
 
         if @options[:osinfo_version] === 0
           warning = <<-eow
@@ -144,7 +143,7 @@ eow
     end
 
     def execute
-      BeakerHostGenerator::Generator.new.generate(@tokens, @options)
+      BeakerHostGenerator::Generator.new.generate(@layout, @options)
     end
 
     def execute!
@@ -152,52 +151,6 @@ eow
     end
 
     private
-
-    # Breaks apart the host input string into chunks suitable for processing
-    # by the generator. Returns an array of substrings of the input spec string.
-    #
-    # The input string is expected to be properly formatted using the dash `-`
-    # character as a delimiter. Dashes may also be used within braces `{...}`,
-    # which are used to define arbitrary key-values on a node.
-    #
-    # @param spec [String] Well-formatted string specification of the hosts to
-    #                      generate. For example `"centos6-64m-debian8-32a"`.
-    # @returns [Array<String>] Input string split into substrings suitable for
-    #                          processing by the generator. For example
-    #                          `["centos6", "64m", "debian8", "32a"]`.
-    def tokenize_input(spec)
-      # Here we allow dashes in certain parts of the spec string
-      # i.e. "centos6-64m{hostname=foo-bar}-debian8-32"
-      # by first replacing all occurrences of - with | that exist within
-      # the braces {...}.
-      #
-      # So we'd end up with:
-      #   "centos6-64m{hostname=foo|bar}-debian8-32"
-      #
-      # Which we can then simply split on - into:
-      #   ["centos6", "64{hostname=foo|bar}", "debian8", "32"]
-      #
-      # And then finally turn the | back into - now that we've
-      # properly decomposed the spec string:
-      #   ["centos6", "64{hostname=foo-bar}", "debian8", "32"]
-      #
-      # NOTE we've specifically chosen to use the pipe character |
-      # due to its unlikely occurrence in the user input string.
-      spec = String.new(spec) # Copy so we can replace characters inline
-      within_braces = false
-      spec.chars.each_with_index do |char, index|
-        case char
-        when '{'
-          within_braces = true
-        when '}'
-          within_braces = false
-        when '-'
-          spec[index] = '|' if within_braces
-        end
-      end
-      tokens = spec.split('-')
-      tokens.map { |t| t.gsub('|', '-') }
-    end
 
     # Prints to stdout a human-readable listing of all supported values for
     # the following: platforms, architectures, roles, and hypervisors.

--- a/lib/beaker-hostgenerator/cli.rb
+++ b/lib/beaker-hostgenerator/cli.rb
@@ -127,7 +127,7 @@ Usage: beaker-hostgenerator [options] <layout>
         raise BeakerHostGenerator::Exceptions::SafeEarlyExit
       else
         # Tokenizing the config definition for great justice
-        @tokens = __tokenize_input(argv[0])
+        @tokens = tokenize_input(argv[0])
 
         if @options[:osinfo_version] === 0
           warning = <<-eow
@@ -143,6 +143,16 @@ eow
       end
     end
 
+    def execute
+      BeakerHostGenerator::Generator.new.generate(@tokens, @options)
+    end
+
+    def execute!
+      puts execute
+    end
+
+    private
+
     # Breaks apart the host input string into chunks suitable for processing
     # by the generator. Returns an array of substrings of the input spec string.
     #
@@ -155,7 +165,7 @@ eow
     # @returns [Array<String>] Input string split into substrings suitable for
     #                          processing by the generator. For example
     #                          `["centos6", "64m", "debian8", "32a"]`.
-    def __tokenize_input(spec)
+    def tokenize_input(spec)
       # Here we allow dashes in certain parts of the spec string
       # i.e. "centos6-64m{hostname=foo-bar}-debian8-32"
       # by first replacing all occurrences of - with | that exist within
@@ -215,14 +225,6 @@ eow
       BeakerHostGenerator::Hypervisor.supported_hypervisors().keys.each do |k|
         puts "   #{k}"
       end
-    end
-
-    def execute
-      BeakerHostGenerator::Generator.new.generate(@tokens, @options)
-    end
-
-    def execute!
-      puts execute
     end
   end
 end

--- a/lib/beaker-hostgenerator/data.rb
+++ b/lib/beaker-hostgenerator/data.rb
@@ -64,12 +64,12 @@ module BeakerHostGenerator
       }
     }
 
-    def base_host_config
+    def base_host_config(options)
       {
-        'pe_dir' => pe_dir(pe_version, pe_family),
-        'pe_ver' => pe_version,
-        'pe_upgrade_dir' => pe_dir(pe_upgrade_version, pe_upgrade_family),
-        'pe_upgrade_ver' => pe_upgrade_version,
+        'pe_dir' => options[:pe_dir] || pe_dir(pe_version, pe_family),
+        'pe_ver' => options[:pe_ver] || pe_version,
+        'pe_upgrade_dir' => options[:pe_upgrade_dir] || pe_dir(pe_upgrade_version, pe_upgrade_family),
+        'pe_upgrade_ver' => options[:pe_upgrade_ver] || pe_upgrade_version,
       }
     end
 
@@ -925,6 +925,9 @@ module BeakerHostGenerator
 
     # Capture role and bit width information about the node.
     #
+    # See Ruby Regexp class for information on the capture groups used below.
+    # http://ruby-doc.org/core-2.2.0/Regexp.html#class-Regexp-label-Character+Classes
+    #
     # Examples node specs and their resulting roles
     #
     #  64compile_master,zuul,meow.a
@@ -946,7 +949,7 @@ module BeakerHostGenerator
     #   * agent
     #   * database
     #
-    NODE_REGEX=/\A(?<bits>\d+)((?<arbitrary_roles>([[:lower:]_]*|\,)*)\.)?(?<roles>[uacldfm]*)\Z/
+    NODE_REGEX=/\A(?<bits>\d+)((?<arbitrary_roles>([[:lower:]_]*|\,)*)\.)?(?<roles>[uacldfm]*)(?<host_settings>\{[[:graph:]]*\})?\Z/
 
     # Returns the map of OS info for the given version of this library.
     # The current version is always available as version 0 (zero).

--- a/lib/beaker-hostgenerator/data.rb
+++ b/lib/beaker-hostgenerator/data.rb
@@ -923,34 +923,6 @@ module BeakerHostGenerator
       }
     end
 
-    # Capture role and bit width information about the node.
-    #
-    # See Ruby Regexp class for information on the capture groups used below.
-    # http://ruby-doc.org/core-2.2.0/Regexp.html#class-Regexp-label-Character+Classes
-    #
-    # Examples node specs and their resulting roles
-    #
-    #  64compile_master,zuul,meow.a
-    #   * compile_master
-    #   * zuul
-    #   * meow
-    #   * agent
-    #
-    #  32herp.cdma
-    #   * herp
-    #   * dashboard
-    #   * database
-    #   * master
-    #   * agent
-    #
-    #  64dashboard,master,agent,database.
-    #   * dashboard
-    #   * master
-    #   * agent
-    #   * database
-    #
-    NODE_REGEX=/\A(?<bits>\d+)((?<arbitrary_roles>([[:lower:]_]*|\,)*)\.)?(?<roles>[uacldfm]*)(?<host_settings>\{[[:graph:]]*\})?\Z/
-
     # Returns the map of OS info for the given version of this library.
     # The current version is always available as version 0 (zero).
     # Throws an exception if the version number is unrecognized.
@@ -958,8 +930,8 @@ module BeakerHostGenerator
     # This is intended to be the primary access point for the OS info maps
     # defined in `osinfo`, `osinfo_bhgv1`, etc.
     #
-    # See also `get_platforms`, `get_platform_info`, and `is_ostype_token?` for
-    # common operations on this OS info map.
+    # See also `get_platforms`, `get_platform_info`, for common operations on
+    # this OS info map.
     def get_osinfo(bhg_version)
       case bhg_version
       when 0
@@ -1010,29 +982,6 @@ module BeakerHostGenerator
     def get_platform_info(bhg_version, platform, hypervisor)
       info = get_osinfo(bhg_version)[platform]
       {}.deep_merge!(info[:general]).deep_merge!(info[hypervisor])
-    end
-
-    # Tests if a string token represents an OS platform (i.e. "centos6" or
-    # "debian8") and not another part of the host specification like the
-    # architecture bit (i.e. "32" or "64").
-    #
-    # This is used when parsing the host generator input string to determine
-    # if we're introducing a host for a new platform or if we're adding another
-    # host for a current platform.
-    #
-    # @param [String] token A piece of the host generator input that might refer
-    #                 to an OS platform. For example `"centos6"` or `"debian8"`.
-    #
-    # @param [Integer] bhg_version The version of OS info to use when testing
-    #                  for whether the token represent an OS platform.
-    def is_ostype_token?(token, bhg_version)
-      get_platforms(bhg_version).each do |platform|
-        ostype = platform.split('-')[0]
-        if ostype == token
-          return true
-        end
-      end
-      return false
     end
 
     # Perform any adjustments or modifications necessary to the given node

--- a/lib/beaker-hostgenerator/data.rb
+++ b/lib/beaker-hostgenerator/data.rb
@@ -1,8 +1,7 @@
 module BeakerHostGenerator
-  # Contains all the information that ends up in the generated hosts
+  # Contains all the platform information that ends up in the generated hosts
   # configuration. This includes the various OS-specific platform
-  # configuration, PE-specific installation & upgrade configuration, and
-  # Beaker-supported roles.
+  # configuration, and PE-specific installation & upgrade configuration.
   #
   # Any data used by any hypervisor or any other abstraction should be defined
   # in this module, likely in the `osinfo` hash. The hypervisor implementation
@@ -45,16 +44,6 @@ module BeakerHostGenerator
     end
 
     PE_USE_WIN32 = ENV['pe_use_win32']
-
-    ROLES = {
-      'a' => 'agent',
-      'u' => 'ca',
-      'l' => 'classifier',
-      'c' => 'dashboard',
-      'd' => 'database',
-      'f' => 'frictionless',
-      'm' => 'master',
-    }
 
     BASE_CONFIG = {
       'HOSTS' => {},

--- a/lib/beaker-hostgenerator/generator.rb
+++ b/lib/beaker-hostgenerator/generator.rb
@@ -113,19 +113,25 @@ module BeakerHostGenerator
       end
 
       if node_info['host_settings']
-        # Turns a string like "{foo=bar,this=that}" into a
-        # hash like {'foo' => 'bar', 'this' => 'that'}.
-        node_info['host_settings'] = Hash[
-          node_info['host_settings'].
-          delete('{}').
-          split(',').
-          map { |keyvalue| keyvalue.split('=') }
-        ]
+        node_info['host_settings'] =
+          __settings_string_to_map(node_info['host_settings'])
       else
         node_info['host_settings'] = {}
       end
 
       return node_info
+    end
+
+    # Transforms the arbitrary host settings map from a string representation
+    # to a proper hash map data structure. The string is expected to be of the
+    # form "{key1=value1,key2=value2,...}".
+    def __settings_string_to_map(host_settings)
+      Hash[
+        host_settings.
+        delete('{}').
+        split(',').
+        map { |keyvalue| keyvalue.split('=') }
+      ]
     end
 
     def __generate_host_roles(node_info)

--- a/lib/beaker-hostgenerator/hypervisor.rb
+++ b/lib/beaker-hostgenerator/hypervisor.rb
@@ -18,14 +18,20 @@ module BeakerHostGenerator
     # given node. If no hypervisor is specified in the node info, then the
     # hypervisor specified in the options will be created.
     #
+    # @param node_info [Hash{String=>Object}] Node data parsed from the input
+    #                                         spec string.
+    #
     # @option options [String] :hypervisor The string name of the hypervisor to
     #                          create. An exception will be thrown if the
     #                          hypervisor is unrecognized.
     def self.create(node_info, options)
-      hypervisor = options[:hypervisor] || 'vmpooler'
+      hypervisor =
+        node_info['host_settings']['hypervisor'] || options[:hypervisor]
       case hypervisor
       when 'vmpooler'
         BeakerHostGenerator::Hypervisor::Vmpooler.new
+      when 'none'
+        BeakerHostGenerator::Hypervisor::None.new
       else
         raise "Invalid hypervisor #{hypervisor}"
       end
@@ -40,7 +46,7 @@ module BeakerHostGenerator
       # case the returned map will be merged in with global configuration from
       # other hypervisors.
       def global_config()
-        raise "Method 'global_config' not implemented!"
+        {}
       end
 
       # Returns a map of host configuration for a single node.
@@ -75,3 +81,4 @@ end
 # bottom of this file to avoid circular references between this file and the
 # hypervisor implementation files.
 require 'beaker-hostgenerator/hypervisor/vmpooler'
+require 'beaker-hostgenerator/hypervisor/none'

--- a/lib/beaker-hostgenerator/hypervisor/none.rb
+++ b/lib/beaker-hostgenerator/hypervisor/none.rb
@@ -1,0 +1,17 @@
+require 'beaker-hostgenerator/hypervisor'
+require 'beaker-hostgenerator/data'
+require 'deep_merge'
+
+module BeakerHostGenerator::Hypervisor
+  class None < BeakerHostGenerator::Hypervisor::Interface
+    include BeakerHostGenerator::Data
+
+    def generate_node(node_info, base_config, bhg_version)
+      platform = node_info['platform']
+      general_info = get_platform_info(bhg_version, platform, :general)
+      base_config.deep_merge! general_info
+      base_config['hypervisor'] = 'none'
+      return base_config
+    end
+  end
+end

--- a/lib/beaker-hostgenerator/hypervisor/vmpooler.rb
+++ b/lib/beaker-hostgenerator/hypervisor/vmpooler.rb
@@ -14,28 +14,18 @@ module BeakerHostGenerator
       end
 
       def generate_node(node_info, base_config, bhg_version)
-        host_config = {}
-        host_config.deep_merge! base_config
-
         # set hypervisor
-        host_config['hypervisor'] = 'vmpooler'
+        base_config['hypervisor'] = 'vmpooler'
 
-        # generate node definition
-        ostype = node_info['ostype']
-        nodeid = node_info['nodeid']
-        bits = node_info['bits']
-
-        platform = "#{ostype}-#{bits}"
-        name = "#{platform}-#{nodeid}"
-
+        platform = node_info['platform']
         platform_info = get_platform_info(bhg_version, platform, :vmpooler)
-        host_config.deep_merge! platform_info
+        base_config.deep_merge! platform_info
 
-        # Some vmpooler/vsphere platforms have special requirements. We munge the
-        # node host_config here if that is necessary.
-        fixup_node host_config
+        # Some vmpooler/vsphere platforms have special requirements.
+        # We munge the node host config here if that is necessary.
+        fixup_node base_config
 
-        return name, host_config
+        return base_config
       end
     end
   end

--- a/lib/beaker-hostgenerator/parser.rb
+++ b/lib/beaker-hostgenerator/parser.rb
@@ -1,0 +1,181 @@
+require 'beaker-hostgenerator/data'
+require 'beaker-hostgenerator/exceptions'
+
+module BeakerHostGenerator
+  # Functions for parsing the raw user input host layout string and turning
+  # them into proper data structures suitable for processing by the Generator.
+  #
+  # The functions mainly perform data type conversions, like splitting the
+  # single input string into a list of strings, each of which will be processed
+  # further by other functions in this module.
+  #
+  # For example, given the raw user input string that defines the host layout,
+  # you would first split it into tokens via `tokenize_layout`, and then for
+  # each token you would call `is_ostype_token?` and/or `parse_node_info_token`.
+  module Parser
+
+    # Capture role and bit width information about the node.
+    #
+    # See Ruby Regexp class for information on the capture groups used below.
+    # http://ruby-doc.org/core-2.2.0/Regexp.html#class-Regexp-label-Character+Classes
+    #
+    # Examples node specs and their resulting roles
+    #
+    #  64compile_master,zuul,meow.a
+    #   * compile_master
+    #   * zuul
+    #   * meow
+    #   * agent
+    #
+    #  32herp.cdma
+    #   * herp
+    #   * dashboard
+    #   * database
+    #   * master
+    #   * agent
+    #
+    #  64dashboard,master,agent,database.
+    #   * dashboard
+    #   * master
+    #   * agent
+    #   * database
+    #
+    NODE_REGEX=/\A(?<bits>\d+)((?<arbitrary_roles>([[:lower:]_]*|\,)*)\.)?(?<roles>[uacldfm]*)(?<host_settings>\{[[:graph:]]*\})?\Z/
+
+    module_function
+
+    # Breaks apart the host input string into chunks suitable for processing
+    # by the generator. Returns an array of substrings of the input spec string.
+    #
+    # The input string is expected to be properly formatted using the dash `-`
+    # character as a delimiter. Dashes may also be used within braces `{...}`,
+    # which are used to define arbitrary key-values on a node.
+    #
+    # @param spec [String] Well-formatted string specification of the hosts to
+    #                      generate. For example `"centos6-64m-debian8-32a"`.
+    # @returns [Array<String>] Input string split into substrings suitable for
+    #                          processing by the generator. For example
+    #                          `["centos6", "64m", "debian8", "32a"]`.
+    def tokenize_layout(layout_spec)
+      # Here we allow dashes in certain parts of the spec string
+      # i.e. "centos6-64m{hostname=foo-bar}-debian8-32"
+      # by first replacing all occurrences of - with | that exist within
+      # the braces {...}.
+      #
+      # So we'd end up with:
+      #   "centos6-64m{hostname=foo|bar}-debian8-32"
+      #
+      # Which we can then simply split on - into:
+      #   ["centos6", "64{hostname=foo|bar}", "debian8", "32"]
+      #
+      # And then finally turn the | back into - now that we've
+      # properly decomposed the spec string:
+      #   ["centos6", "64{hostname=foo-bar}", "debian8", "32"]
+      #
+      # NOTE we've specifically chosen to use the pipe character |
+      # due to its unlikely occurrence in the user input string.
+      spec = String.new(layout_spec) # Copy so we can replace characters inline
+      within_braces = false
+      spec.chars.each_with_index do |char, index|
+        case char
+        when '{'
+          within_braces = true
+        when '}'
+          within_braces = false
+        when '-'
+          spec[index] = '|' if within_braces
+        end
+      end
+      tokens = spec.split('-')
+      tokens.map { |t| t.gsub('|', '-') }
+    end
+
+    # Tests if a string token represents an OS platform (i.e. "centos6" or
+    # "debian8") and not another part of the host specification like the
+    # architecture bit (i.e. "32" or "64").
+    #
+    # This is used when parsing the host generator input string to determine
+    # if we're introducing a host for a new platform or if we're adding another
+    # host for a current platform.
+    #
+    # @param [String] token A piece of the host generator input that might refer
+    #                 to an OS platform. For example `"centos6"` or `"debian8"`.
+    #
+    # @param [Integer] bhg_version The version of OS info to use when testing
+    #                  for whether the token represent an OS platform.
+    def is_ostype_token?(token, bhg_version)
+      BeakerHostGenerator::Data.get_platforms(bhg_version).each do |platform|
+        ostype = platform.split('-')[0]
+        if ostype == token
+          return true
+        end
+      end
+      return false
+    end
+
+    # Converts a string token that represents a node (and not an OS type) into
+    # a proper hash map with keys representing the various regex capture groups
+    # in `NODE_REGEX` and values being the captured text.
+    #
+    # Throws an exception if the token is not in the expected formatted, as
+    # determined by `NODE_REGEX.match`.
+    #
+    # It is expected that the `Generator` will have initimate knowledge about
+    # the keys and values in the returned map, as it may be adjusted and given
+    # to the hypervisors or other abstractions for processing.
+    #
+    # @param token [String] The portion of the user input layout specifiction
+    #                       that describes the node (and not the OS platform).
+    #                       For example `"64myrole.mdca"`.
+    #
+    # @returns [Hash{String=>Object}] A map containing the regex capture groups
+    #                                 suitable for processing by the Generator
+    #                                 and hypervisors.
+    def parse_node_info_token(token)
+      node_info = NODE_REGEX.match(token)
+
+      if node_info
+        node_info = Hash[ node_info.names.zip( node_info.captures ) ]
+      else
+        raise BeakerHostGenerator::Exceptions::InvalidNodeSpecError.new,
+              "Invalid node_info token: #{token}"
+      end
+
+      if node_info['arbitrary_roles']
+        node_info['arbitrary_roles'] =
+          node_info['arbitrary_roles'].split(',') || ''
+      else
+        # Default to empty list to avoid having to check for nil elsewhere
+        node_info['arbitrary_roles'] = []
+      end
+
+      if node_info['host_settings']
+        node_info['host_settings'] =
+          settings_string_to_map(node_info['host_settings'])
+      else
+        node_info['host_settings'] = {}
+      end
+
+      return node_info
+    end
+
+    # Transforms the arbitrary host settings map from a string representation
+    # to a proper hash map data structure for merging into the host
+    # configuration.
+    #
+    # The string is expected to be of the form "{key1=value1,key2=value2,...}".
+    #
+    # @param host_settings [String] Non-nil user input string that defines host
+    #                               specific settings.
+    #
+    # @returns [Hash{String=>String}] The host_settings string as a map.
+    def settings_string_to_map(host_settings)
+      Hash[
+        host_settings.
+        delete('{}').
+        split(',').
+        map { |keyvalue| keyvalue.split('=') }
+      ]
+    end
+  end
+end

--- a/lib/beaker-hostgenerator/roles.rb
+++ b/lib/beaker-hostgenerator/roles.rb
@@ -1,18 +1,29 @@
 module BeakerHostGenerator
-  class Roles
+  module Roles
 
-    def initialize
-    end
+    ROLES = {
+      'a' => 'agent',
+      'u' => 'ca',
+      'l' => 'classifier',
+      'c' => 'dashboard',
+      'd' => 'database',
+      'f' => 'frictionless',
+      'm' => 'master',
+    }
 
-    def compile_master
-      return {
-        'frictionless_options' => {
-          'main' => {
-            'dns_alt_names' => 'puppet',
-            'environmentpath' => '/etc/puppetlabs/puppet/environments',
-          }
+    ROLE_CONFIG = {
+      'compile_master' => {
+        'main' => {
+          'dns_alt_names' => 'puppet',
+          'environmentpath' => '/etc/puppetlabs/puppet/environments',
         }
       }
+    }
+
+    module_function
+
+    def get_role_config(role)
+      ROLE_CONFIG[role] || {}
     end
   end
 end

--- a/lib/beaker-hostgenerator/util.rb
+++ b/lib/beaker-hostgenerator/util.rb
@@ -1,4 +1,5 @@
 require 'beaker-hostgenerator/data'
+require 'beaker-hostgenerator/roles'
 require 'beaker-hostgenerator/hypervisor/vmpooler'
 require 'deep_merge'
 
@@ -38,7 +39,7 @@ module BeakerHostGenerator
     end
 
     def get_roles
-      BeakerHostGenerator::Data::ROLES
+      BeakerHostGenerator::Roles.ROLES
     end
   end
 end

--- a/spec/beaker-hostgenerator/generator_spec.rb
+++ b/spec/beaker-hostgenerator/generator_spec.rb
@@ -6,84 +6,89 @@ require 'beaker-hostgenerator'
 require 'util/generator_helpers'
 
 module BeakerHostGenerator
-      describe Generator do
-        let(:generator) { BeakerHostGenerator::Generator.new }
+  describe Generator do
+    let(:generator) { BeakerHostGenerator::Generator.new }
 
-        describe '__generate_host_roles' do
-          it 'Generates a list of roles' do
-            {
-              {
-                "roles" => "aulcdfm",
-                "arbitrary_roles" => [],
-              } => [
-                'agent',
-                'ca',
-                'classifier',
-                'dashboard',
-                'database',
-                'frictionless',
-                'master',
-                ],
-              {
-                "roles" => "a",
-                "arbitrary_roles" => ["meow","hello","compile_master"],
-              } => [
-                'agent',
-                'meow',
-                'hello',
-                'compile_master',
-                ],
-              {
-                "roles" => "",
-                "arbitrary_roles" => ["compile_master"],
-              } => [
-                'compile_master'
-                ],
-              {
-                "roles" => "",
-                "arbitrary_roles" => [],
-              } => [],
-            }.each do |node_info, roles|
-              expect( generator.__generate_host_roles(node_info) ).to eq( roles )
-            end
-          end
+    describe 'get_host_roles' do
+      it 'Expands default roles and merges in arbitrary roles' do
+        {
+          {
+            "roles" => "aulcdfm",
+            "arbitrary_roles" => [],
+          } => [
+            'agent',
+            'ca',
+            'classifier',
+            'dashboard',
+            'database',
+            'frictionless',
+            'master',
+          ],
+          {
+            "roles" => "a",
+            "arbitrary_roles" => ["meow","hello","compile_master"],
+          } => [
+            'agent',
+            'meow',
+            'hello',
+            'compile_master',
+          ],
+          {
+            "roles" => "",
+            "arbitrary_roles" => ["compile_master"],
+          } => [
+            'compile_master'
+          ],
+          {
+            "roles" => "",
+            "arbitrary_roles" => [],
+          } => [],
+        }.each do |node_info, roles|
+          expect( generator.get_host_roles(node_info) ).to eq( roles )
         end
-
-        shared_examples "fixtures" do |fixture_hash|
-          arguments = fixture_hash["arguments_string"]
-          it "beaker-hostgenerator #{arguments}" do
-            arguments = arguments.split
-            STDERR.reopen("stderr.txt", "w")
-            fixture_hash['environment_variables'].each do |key, value|
-              ENV[key] = value
-            end
-
-            cli = BeakerHostGenerator::CLI.new(arguments)
-            if fixture_hash['expected_exception']
-              # Turn fully-qualified classname string into an actual Class object.
-              expected_class = eval fixture_hash['expected_exception']
-              expect { cli.execute }.to raise_error(expected_class)
-            else
-              test_hash = YAML.load(cli.execute)
-              expect(test_hash).to eq(fixture_hash['expected_hash'])
-            end
-
-            fixture_hash['environment_variables'].each_key do |key|
-              ENV[key] = nil
-            end
-          end
-        end
-
-        context "Fixtures" do
-          Find.find 'test/fixtures' do |f|
-            context "#{f}" do
-              if File.directory?(f)
-                next
-              end
-              include_examples "fixtures", YAML.load_file(f)
-            end
-          end
-        end
-
       end
+    end
+
+    shared_examples "fixtures" do |fixture_hash|
+      arguments = fixture_hash["arguments_string"]
+      it "beaker-hostgenerator #{arguments}" do
+        arguments = arguments.split
+        STDERR.reopen("stderr.txt", "w")
+        fixture_hash['environment_variables'].each do |key, value|
+          ENV[key] = value
+        end
+
+        cli = BeakerHostGenerator::CLI.new(arguments)
+        if fixture_hash['expected_exception']
+          # Turn fully-qualified classname string into actual Class object.
+          # We have to manually descend into each Module that makes up the
+          # fully-qualified path to the error class.
+          qualified_classname = fixture_hash['expected_exception'].split('::')
+          expected_class = qualified_classname.reduce(Object) do |accum, e|
+            accum.const_get(e)
+          end
+          expect { cli.execute }.to raise_error(expected_class)
+        else
+          test_hash = YAML.load(cli.execute)
+          expect(test_hash).to eq(fixture_hash['expected_hash'])
+        end
+
+        fixture_hash['environment_variables'].each_key do |key|
+          ENV[key] = nil
+        end
+      end
+    end
+
+    context "Fixtures" do
+      Find.find 'test/fixtures' do |f|
+        context "#{f}" do
+          if File.directory?(f)
+            next
+          end
+          include_examples "fixtures", YAML.load_file(f)
+        end
+      end
+    end
+
+  end
 end

--- a/spec/beaker-hostgenerator/generator_spec.rb
+++ b/spec/beaker-hostgenerator/generator_spec.rb
@@ -57,12 +57,20 @@ module BeakerHostGenerator
             fixture_hash['environment_variables'].each do |key, value|
               ENV[key] = value
             end
+
             cli = BeakerHostGenerator::CLI.new(arguments)
-            test_hash = YAML.load(cli.execute)
+            if fixture_hash['expected_exception']
+              # Turn fully-qualified classname string into an actual Class object.
+              expected_class = eval fixture_hash['expected_exception']
+              expect { cli.execute }.to raise_error(expected_class)
+            else
+              test_hash = YAML.load(cli.execute)
+              expect(test_hash).to eq(fixture_hash['expected_hash'])
+            end
+
             fixture_hash['environment_variables'].each_key do |key|
               ENV[key] = nil
             end
-            expect(test_hash).to eq(fixture_hash["expected_hash"])
           end
         end
 

--- a/spec/beaker-hostgenerator/generator_spec.rb
+++ b/spec/beaker-hostgenerator/generator_spec.rb
@@ -62,6 +62,7 @@ module BeakerHostGenerator
               "roles" => "",
               "arbitrary_roles" => [],
               "bits" => "64",
+              "host_settings" => {}
             })
           end
 
@@ -71,6 +72,7 @@ module BeakerHostGenerator
               "roles" => "mad",
               "arbitrary_roles" => ["compile_master", "ca", "blah"],
               "bits" => "64",
+              "host_settings" => {}
             })
           end
 
@@ -85,6 +87,7 @@ module BeakerHostGenerator
                 "roles" => "",
                 "arbitrary_roles" => ["compile_master", "ca", "blah"],
                 "bits" => "64",
+                "host_settings" => {}
               })
             end
           end

--- a/spec/beaker-hostgenerator/generator_spec.rb
+++ b/spec/beaker-hostgenerator/generator_spec.rb
@@ -49,50 +49,6 @@ module BeakerHostGenerator
           end
         end
 
-        describe '__parse_node_info_token' do
-
-          it 'Raises InvalidNodeSpecError for invalid tokens.' do
-            expect{ generator.__parse_node_info_token("64compile_master") }.to \
-              raise_error(BeakerHostGenerator::Exceptions::InvalidNodeSpecError)
-          end
-
-          it 'Supports no roles in the spec.' do
-            node_info = generator.__parse_node_info_token("64")
-            expect( node_info ).to eq({
-              "roles" => "",
-              "arbitrary_roles" => [],
-              "bits" => "64",
-              "host_settings" => {}
-            })
-          end
-
-          it 'Supports the use of arbitrary roles.' do
-            node_info = generator.__parse_node_info_token("64compile_master,ca,blah.mad")
-            expect( node_info ).to eq({
-              "roles" => "mad",
-              "arbitrary_roles" => ["compile_master", "ca", "blah"],
-              "bits" => "64",
-              "host_settings" => {}
-            })
-          end
-
-          context 'When using arbitrary roles'do
-            it 'Fails without a role-type delimiter (a period)' do
-              expect{ generator.__parse_node_info_token("64compile_master,ca,blah") }.to \
-                raise_error(BeakerHostGenerator::Exceptions::InvalidNodeSpecError)
-            end
-            it 'It supports no static roles.' do
-              node_info = generator.__parse_node_info_token("64compile_master,ca,blah.")
-              expect( node_info ).to eq({
-                "roles" => "",
-                "arbitrary_roles" => ["compile_master", "ca", "blah"],
-                "bits" => "64",
-                "host_settings" => {}
-              })
-            end
-          end
-        end
-
         shared_examples "fixtures" do |fixture_hash|
           arguments = fixture_hash["arguments_string"]
           it "beaker-hostgenerator #{arguments}" do

--- a/spec/beaker-hostgenerator/parser_spec.rb
+++ b/spec/beaker-hostgenerator/parser_spec.rb
@@ -1,0 +1,53 @@
+require 'beaker-hostgenerator/parser'
+
+module BeakerHostGenerator
+  describe Parser do
+    include BeakerHostGenerator::Parser
+
+    describe 'parse_node_info_token' do
+
+      it 'Raises InvalidNodeSpecError for invalid tokens.' do
+        expect { parse_node_info_token("64compile_master") }.
+          to raise_error(BeakerHostGenerator::Exceptions::InvalidNodeSpecError)
+      end
+
+      it 'Supports no roles in the spec.' do
+        expect( parse_node_info_token("64") ).
+          to eq({
+                  "roles" => "",
+                  "arbitrary_roles" => [],
+                  "bits" => "64",
+                  "host_settings" => {}
+                })
+      end
+
+      it 'Supports the use of arbitrary roles.' do
+        expect( parse_node_info_token("64compile_master,ca,blah.mad") ).
+          to eq({
+                  "roles" => "mad",
+                  "arbitrary_roles" => ["compile_master", "ca", "blah"],
+                  "bits" => "64",
+                  "host_settings" => {}
+                })
+      end
+
+      context 'When using arbitrary roles' do
+
+        it 'Fails without a role-type delimiter (a period)' do
+          expect { parse_node_info_token("64compile_master,ca,blah") }.
+            to raise_error(BeakerHostGenerator::Exceptions::InvalidNodeSpecError)
+        end
+
+        it 'It supports no static roles.' do
+          expect( parse_node_info_token("64compile_master,ca,blah.") ).
+            to eq({
+                    "roles" => "",
+                    "arbitrary_roles" => ["compile_master", "ca", "blah"],
+                    "bits" => "64",
+                    "host_settings" => {}
+                  })
+        end
+      end
+    end
+  end
+end

--- a/spec/beaker-hostgenerator/parser_spec.rb
+++ b/spec/beaker-hostgenerator/parser_spec.rb
@@ -48,6 +48,37 @@ module BeakerHostGenerator
                   })
         end
       end
+
+      context 'When using arbitrary host settings' do
+        it 'Supports arbitrary whitespace' do
+          expect( parse_node_info_token("64{ k1=v1, k2=v2,  k3 = v3 ,  k4  =v4  }") ).
+            to eq({
+                    "roles" => "",
+                    "arbitrary_roles" => [],
+                    "bits" => "64",
+                    "host_settings" => {
+                      "k1" => "v1",
+                      "k2" => "v2",
+                      "k3" => "v3",
+                      "k4" => "v4"
+                    }
+                  })
+        end
+
+        it 'Raises InvalidNodeSpecError for malformed key-value pairs' do
+          expect { parse_node_info_token("64{foo=bar=baz}") }.
+            to raise_error(BeakerHostGenerator::Exceptions::InvalidNodeSpecError)
+
+          expect { parse_node_info_token("64{foo=}") }.
+            to raise_error(BeakerHostGenerator::Exceptions::InvalidNodeSpecError)
+
+          expect { parse_node_info_token("64{=bar}") }.
+            to raise_error(BeakerHostGenerator::Exceptions::InvalidNodeSpecError)
+
+          expect { parse_node_info_token("64{=}") }.
+            to raise_error(BeakerHostGenerator::Exceptions::InvalidNodeSpecError)
+        end
+      end
     end
   end
 end

--- a/test/fixtures/per-host-settings/arbitrary-settings.yaml
+++ b/test/fixtures/per-host-settings/arbitrary-settings.yaml
@@ -1,0 +1,57 @@
+---
+arguments_string: redhat7-64role_a,role_b.m{hypervisor=none,hostname=redhat,vmhostname=vm-redhat,ip=1.2.3.4}-sles10-32a-64a{key=value-with-dashes}-64dc
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    redhat:
+      pe_dir:
+      pe_ver:
+      pe_upgrade_dir:
+      pe_upgrade_ver:
+      platform: el-7-x86_64
+      hypervisor: none
+      vmhostname: vm-redhat
+      ip: 1.2.3.4
+      roles:
+      - agent
+      - master
+      - role_a
+      - role_b
+    sles10-32-1:
+      pe_dir:
+      pe_ver:
+      pe_upgrade_dir:
+      pe_upgrade_ver:
+      hypervisor: vmpooler
+      platform: sles-10-i386
+      template: sles-10-i386
+      roles:
+      - agent
+    sles10-64-2:
+      pe_dir:
+      pe_ver:
+      pe_upgrade_dir:
+      pe_upgrade_ver:
+      hypervisor: vmpooler
+      platform: sles-10-x86_64
+      template: sles-10-x86_64
+      key: value-with-dashes
+      roles:
+      - agent
+    sles10-64-3:
+      pe_dir:
+      pe_ver:
+      pe_upgrade_dir:
+      pe_upgrade_ver:
+      hypervisor: vmpooler
+      platform: sles-10-x86_64
+      template: sles-10-x86_64
+      roles:
+      - agent
+      - database
+      - dashboard
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception:

--- a/test/fixtures/per-host-settings/every-hypervisor.yaml
+++ b/test/fixtures/per-host-settings/every-hypervisor.yaml
@@ -1,0 +1,30 @@
+---
+arguments_string: centos6-64m{hypervisor=vmpooler}-debian8-32a{hypervisor=none}
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    centos6-64-1:
+      pe_dir:
+      pe_ver:
+      pe_upgrade_dir:
+      pe_upgrade_ver:
+      hypervisor: vmpooler
+      platform: el-6-x86_64
+      template: centos-6-x86_64
+      roles:
+      - agent
+      - master
+    debian8-32-1:
+      pe_dir:
+      pe_ver:
+      pe_upgrade_dir:
+      pe_upgrade_ver:
+      platform: debian-8-i386
+      hypervisor: none
+      roles:
+      - agent
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception:

--- a/test/fixtures/per-host-settings/malformed-input.yaml
+++ b/test/fixtures/per-host-settings/malformed-input.yaml
@@ -1,0 +1,5 @@
+---
+arguments_string: 'centos6-64m\ {foo=bar}'
+environment_variables: {}
+expected_hash:
+expected_exception: BeakerHostGenerator::Exceptions::InvalidNodeSpecError


### PR DESCRIPTION
This commit adds a new "none" hypervisor to support non-provisioned
hosts. Non-provisioned hosts require a handful of other host settings to
be specified in order for Beaker to use it properly, so this commit also
adds support for arbitrary key-value host settings.

For example:
```
 $ .. centos6-64m{hypervisor=none,hostname=my-host,vmhostname=othername}
 ---
 HOSTS:
   my-host:
     pe_dir:
     pe_ver:
     pe_upgrade_dir:
     pe_upgrade_ver:
     platform: el-6-x86_64
     hypervisor: none
     vmhostname: othername
     roles:
     - agent
     - master
 CONFIG:
   nfs_server: none
   consoleport: 443
```