### PR TITLE
(QENG-3920) Global host config CLI configuration support

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,37 @@ CONFIG:
   pooling_api: http://vmpooler.delivery.puppetlabs.net/
 ```
 
+### Arbitrary global configuration settings
+
+```
+$ beaker-hostgenerator --global-config {preserve_hosts=onfail\,log_level=debug\,server.ip=12.345.6789} redhat7-64m
+```
+
+Will generate
+
+```yaml
+---
+HOSTS:
+  redhat7-64-1:
+    pe_dir:
+    pe_ver:
+    pe_upgrade_dir:
+    pe_upgrade_ver:
+    hypervisor: vmpooler
+    platform: el-7-x86_64
+    template: redhat-7-x86_64
+    roles:
+    - agent
+    - master
+CONFIG:
+  nfs_server: none
+  consoleport: 443
+  preserve_hosts: onfail
+  log_level: debug
+  server.ip: 12.345.6789
+  pooling_api: http://vmpooler.delivery.puppetlabs.net/
+```
+
 ## Testing
 
 Beaker Host Generator currently uses both rspec and minitest tests. To run both

--- a/lib/beaker-hostgenerator/cli.rb
+++ b/lib/beaker-hostgenerator/cli.rb
@@ -113,6 +113,12 @@ Usage: beaker-hostgenerator [options] <layout>
           @options[:osinfo_version] = version
         end
 
+        opts.on('--global-config KEYVALUE_STRING',
+                "General configuration settings to be included as-is in the " <<
+                "CONFIG section. Value should be in the form '{key=value,...}'.") do |p|
+          @options[:global_config] = p
+        end
+
         opts.on('-h',
                 '--help',
                 'Display command help.') do

--- a/test/fixtures/per-host-settings/with-global-settings.yaml
+++ b/test/fixtures/per-host-settings/with-global-settings.yaml
@@ -1,0 +1,24 @@
+---
+arguments_string: "--global-config {masterless=true,number=1234} redhat7-64c{type=o-negative}"
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    redhat7-64-1:
+      pe_dir:
+      pe_ver:
+      pe_upgrade_dir:
+      pe_upgrade_ver:
+      hypervisor: vmpooler
+      platform: el-7-x86_64
+      template: redhat-7-x86_64
+      type: o-negative
+      roles:
+        - agent
+        - dashboard
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    masterless: true
+    number: 1234
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception:


### PR DESCRIPTION
This commit adds CLI support for specifying global configuration
settings that will be included in the CONFIG section.

For example:
```
  $ beaker-hostgenerator --global-config {master=headless} redhat7-64m
```
```yaml
  ---
  HOSTS:
    redhat7-64-1:
      pe_dir:
      pe_ver:
      pe_upgrade_dir:
      pe_upgrade_ver:
      hypervisor: vmpooler
      platform: el-7-x86_64
      template: redhat-7-x86_64
      roles:
      - agent
      - master
  CONFIG:
    nfs_server: none
    consoleport: 443
    master: headless
    pooling_api: http://vmpooler.delivery.puppetlabs.net/
```