### PR TITLE
(QENG-3377) Add --version CLI flag

### DIFF
--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -4,17 +4,12 @@ require 'beaker-hostgenerator/cli'
 
 class TestUtil < Minitest::Test
 
-  def setup
-    @stderr = StringIO.new
-    @stdout = StringIO.new
-
-    $stderr = @stderr
-    $stdout = @stdout
+  def test_new_with_list_option
+    assert_instance_of(String, BeakerHostGenerator::CLI.new(['--list']).execute)
   end
 
-  def test_new_with_list_option
-    assert_raises(BeakerHostGenerator::Exceptions::SafeEarlyExit) do
-      BeakerHostGenerator::CLI.new(['--list'])
-    end
+  def test_version_option
+    assert_equal(BeakerHostGenerator::Version::STRING,
+                 BeakerHostGenerator::CLI.new(['--version']).execute)
   end
 end

--- a/test/test_stdout.rb
+++ b/test/test_stdout.rb
@@ -1,4 +1,5 @@
 require 'minitest/autorun'
+require 'beaker-hostgenerator/cli'
 require 'beaker-hostgenerator/data'
 
 class TestStdout < Minitest::Test
@@ -12,11 +13,7 @@ class TestStdout < Minitest::Test
   end
 
   def test_default_list_output
-    begin
-      BeakerHostGenerator::CLI.new(['--list'])
-    rescue BeakerHostGenerator::Exceptions::SafeEarlyExit
-    end
-
+    BeakerHostGenerator::CLI.new(['--list']).execute!
     BeakerHostGenerator::Data.get_platforms(0).each do |spec_key|
       assert_match(/.*#{spec_key}.*/, @stdout.string)
     end


### PR DESCRIPTION
This commit adds a -v/--version CLI flag to print the version number.

This also refactors the flow-of-control to remove the need for the
SafeEarlyExit exception by moving all output-generating codepaths out of
the initialize method and into the execute method, and teasing apart the
--list and default generation codepaths. The execute method
now chooses the code path based on the CLI options set in initialize.

While we no longer throw a SafeEarlyExit exception, it's effectively
part of the API so we must wait until the appropriate time/release to
delete it. Existing usages of it should not be broken with the changes
in this commit.