### PR TITLE
(QENG-3808) Support uppercase alphanumeric architectures

### DIFF
--- a/lib/beaker-hostgenerator/parser.rb
+++ b/lib/beaker-hostgenerator/parser.rb
@@ -14,7 +14,28 @@ module BeakerHostGenerator
   # each token you would call `is_ostype_token?` and/or `parse_node_info_token`.
   module Parser
 
-    # Capture role and bit width information about the node.
+    # Parses a single node definition into the following components:
+    #
+    #   * bits             Uppercase-only alphanumeric
+    #                      Examples: 32, 64, POWER, S390X
+    #
+    #   * arbitrary_roles  Lowercase-only alphabetical & underscores
+    #                      Examples: myrole, role_a
+    #
+    #   * roles            Lowercase-only, any combination of: u, a, c, l, d, f, m
+    #                      Examples: m, mdca
+    #
+    #   * host_settings    Any character (see `settings_string_to_map` for details)
+    #                      Examples: {hostname=foo-bar, ip.address=123.4.5.6}
+    #
+    # This regex is the main workhorse for parsing input to beaker-hostgenerator.
+    # There is a bit of pre and post parsing that happens before and after this
+    # regex though.
+    # Before we use this regex, we split the input containing multiple node
+    # definitions into individual node definitions to be parsed by this regex
+    # (see `tokenize_layout`).
+    # After we use this regex, we turn the host_settings key-value string into
+    # a proper Hash map (see `settings_string_to_map`).
     #
     # See Ruby Regexp class for information on the capture groups used below.
     # http://ruby-doc.org/core-2.2.0/Regexp.html#class-Regexp-label-Character+Classes
@@ -40,7 +61,7 @@ module BeakerHostGenerator
     #   * agent
     #   * database
     #
-    NODE_REGEX=/\A(?<bits>\d+)((?<arbitrary_roles>([[:lower:]_]*|\,)*)\.)?(?<roles>[uacldfm]*)(?<host_settings>\{[[:print:]]*\})?\Z/
+    NODE_REGEX=/\A(?<bits>[A-Z0-9]+|\d+)((?<arbitrary_roles>([[:lower:]_]*|\,)*)\.)?(?<roles>[uacldfm]*)(?<host_settings>\{[[:print:]]*\})?\Z/
 
     module_function
 

--- a/spec/beaker-hostgenerator/parser_spec.rb
+++ b/spec/beaker-hostgenerator/parser_spec.rb
@@ -21,6 +21,62 @@ module BeakerHostGenerator
                 })
       end
 
+      context 'When specifying architecture bits' do
+
+        it 'Supports uppercase alphanumeric architecture bits' do
+          expect( parse_node_info_token("SPARC") ).
+            to eq({
+                    "roles" => "",
+                    "arbitrary_roles" => [],
+                    "bits" => "SPARC",
+                    "host_settings" => {}
+                  })
+
+          expect( parse_node_info_token("POWER6") ).
+            to eq({
+                    "roles" => "",
+                    "arbitrary_roles" => [],
+                    "bits" => "POWER6",
+                    "host_settings" => {}
+                  })
+
+          expect( parse_node_info_token("S390X") ).
+            to eq({
+                    "roles" => "",
+                    "arbitrary_roles" => [],
+                    "bits" => "S390X",
+                    "host_settings" => {}
+                  })
+
+        end
+
+        it 'Trailing lowercase characters are parsed as roles' do
+          expect( parse_node_info_token("S390Xm") ).
+            to eq({
+                    "roles" => "m",
+                    "arbitrary_roles" => [],
+                    "bits" => "S390X",
+                    "host_settings" => {}
+                  })
+
+          expect( parse_node_info_token("S390Xcustom.m") ).
+            to eq({
+                    "roles" => "m",
+                    "arbitrary_roles" => ["custom"],
+                    "bits" => "S390X",
+                    "host_settings" => {}
+                  })
+        end
+
+        it 'Rejects lowercase characters that are not at the end' do
+          expect { parse_node_info_token("AbC3") }.
+            to raise_error(BeakerHostGenerator::Exceptions::InvalidNodeSpecError)
+
+          expect { parse_node_info_token("aBC3") }.
+            to raise_error(BeakerHostGenerator::Exceptions::InvalidNodeSpecError)
+        end
+      end
+
       it 'Supports the use of arbitrary roles.' do
         expect( parse_node_info_token("64compile_master,ca,blah.mad") ).
           to eq({


### PR DESCRIPTION
This commit adds support for uppercase-only alphanumeric architecture
bits in platform names. For example, we now support "POWER" or "POWER7"
instead of just "32" or "64".

Uppercase letters allow for backwards compatibility when roles are
specified, which come after the architecture bit. This implementation
relies on the fact that the role and arbitrary role characters are
only lowercase.

This allows us to distinguish between the architecture "POWER" and the
role "m" when parsing the spec "POWERm", as in "aix71-POWERm".