### PR TITLE
(QENG-3946) Support arbitrary hypervisors

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,19 +3,17 @@
 `beaker-hostgenerator` is a command line utility designed to generate beaker
 host config files using a compact command line SUT specification.
 
-It currently supports Puppets' internal [vmpooler][vmpooler] hypervisor and
-static (non-provisioned) nodes, and is designed in a way that makes it possible
-to easily add support for additional hypervisors (any hypervisor type supported
-by [beaker][beaker]).
-
 <!-- markdown-toc start - Don't edit this section. Run M-x markdown-toc-generate-toc again -->
 **Table of Contents**
 
 - [Beaker Host Generator](#beaker-host-generator)
+    - [Hypervisors](#hypervisors)
     - [Usage](#usage)
         - [Simple two-host layout](#simple-two-host-layout)
         - [Single host with Arbitrary Roles](#single-host-with-arbitrary-roles)
         - [Two hosts with multiple hypervisors and arbitrary host settings](#two-hosts-with-multiple-hypervisors-and-arbitrary-host-settings)
+        - [Arbitrary global configuration settings](#arbitrary-global-configuration-settings)
+        - [Custom hypervisor](#custom-hypervisor)
     - [Testing](#testing)
         - [Test Fixtures](#test-fixtures)
             - [Generated Fixtures](#generated-fixtures)
@@ -23,6 +21,23 @@ by [beaker][beaker]).
     - [License](#license)
 
 <!-- markdown-toc end -->
+
+## Hypervisors
+
+Any hypervisor may be specified and generated, but if it's not a built-in
+hypervisor you will have to provide the entire hypervisor configuration as
+input. See the [Custom hypervisor](#custom-hypervisor) example for more
+information.
+
+It currently provides built-in configuration for Puppets' internal
+[vmpooler][vmpooler] hypervisor and static (non-provisioned) nodes, and is
+designed in a way that makes it possible to easily add support for additional
+hypervisors (any hypervisor type supported by [beaker][beaker]).
+
+To see the list of built-in hypervisors you can run:
+```
+$ beaker-hostgenerator --list
+```
 
 ## Usage
 
@@ -169,6 +184,39 @@ CONFIG:
   log_level: debug
   server.ip: 12.345.6789
   pooling_api: http://vmpooler.delivery.puppetlabs.net/
+```
+
+### Custom hypervisor
+
+The following example shows one way of generating a custom hypervisor that
+includes both per-host configuration and global configuration.
+
+The term "custom" in this case signifies that it's not a built-in hypervisor
+(like `vmpooler`), which means we'll have to provide all the configuration
+ourselves as there isn't any built-in configuration for our hypervisor.
+
+```
+$ beaker-hostgenerator --hypervisor=custom --global={custom_api=http://api.custom.net} centos6-64
+```
+
+Will generate
+
+```yaml
+---
+HOSTS:
+  centos6-64-1:
+    pe_dir:
+    pe_ver:
+    pe_upgrade_dir:
+    pe_upgrade_ver:
+    platform: el-6-x86_64
+    hypervisor: custom
+    roles:
+    - agent
+CONFIG:
+  nfs_server: none
+  consoleport: 443
+  custom_api: http://api.custom.net
 ```
 
 ## Testing

--- a/lib/beaker-hostgenerator/cli.rb
+++ b/lib/beaker-hostgenerator/cli.rb
@@ -186,14 +186,14 @@ eow
       result << "   6432 => 64-bit OS with 32-bit Puppet (Windows Only)\n"
       result << "\n\n"
 
-      result << "valid beaker-hostgenerator host roles:\n"
+      result << "built-in beaker-hostgenerator host roles:\n"
       BeakerHostGenerator::Roles::ROLES.each do |k,v|
         result << "   #{k} => #{v}\n"
       end
       result << "\n\n"
 
-      result << "valid beaker-hostgenerator hypervisors:\n"
-      BeakerHostGenerator::Hypervisor.supported_hypervisors().keys.each do |k|
+      result << "built-in beaker-hostgenerator hypervisors:\n"
+      BeakerHostGenerator::Hypervisor.builtin_hypervisors().keys.each do |k|
         result << "   #{k}\n"
       end
 

--- a/lib/beaker-hostgenerator/hypervisor/unknown.rb
+++ b/lib/beaker-hostgenerator/hypervisor/unknown.rb
@@ -3,14 +3,18 @@ require 'beaker-hostgenerator/data'
 require 'deep_merge'
 
 module BeakerHostGenerator::Hypervisor
-  class None < BeakerHostGenerator::Hypervisor::Interface
+  class Unknown < BeakerHostGenerator::Hypervisor::Interface
     include BeakerHostGenerator::Data
+
+    def initialize(name)
+      @name = name
+    end
 
     def generate_node(node_info, base_config, bhg_version)
       platform = node_info['platform']
       general_info = get_platform_info(bhg_version, platform, :general)
       base_config.deep_merge! general_info
-      base_config['hypervisor'] = 'none'
+      base_config['hypervisor'] = @name
       return base_config
     end
   end

--- a/test/fixtures/per-host-settings/arbitrary-hypervisor.yaml
+++ b/test/fixtures/per-host-settings/arbitrary-hypervisor.yaml
@@ -1,0 +1,39 @@
+---
+arguments_string: centos6-64m{hypervisor=vmpooler}-debian8-32a{hypervisor=none}-redhat7-64a{hypervisor=custom}
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    centos6-64-1:
+      pe_dir:
+      pe_ver:
+      pe_upgrade_dir:
+      pe_upgrade_ver:
+      hypervisor: vmpooler
+      platform: el-6-x86_64
+      template: centos-6-x86_64
+      roles:
+      - agent
+      - master
+    debian8-32-1:
+      pe_dir:
+      pe_ver:
+      pe_upgrade_dir:
+      pe_upgrade_ver:
+      platform: debian-8-i386
+      hypervisor: none
+      roles:
+      - agent
+    redhat7-64-1:
+      pe_dir:
+      pe_ver:
+      pe_upgrade_dir:
+      pe_upgrade_ver:
+      platform: el-7-x86_64
+      hypervisor: custom
+      roles:
+      - agent
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception:


### PR DESCRIPTION
This commit allows unknown hypervisors to be specified by the user.
Previously, if the hypervisor specified by the user was not one of the
valid, built-in implementations then an error was thrown notifying the
user that an invalid hypervisor was requested.
Now, this is no longer an error, and instead the host generation will
continue as normal but there will be no hypervisor-specific
configuration. The name of the unknown hypervisor will be the value of
the hypervisor configuration of the hosts.

To implement this, we can repurpose the special `Hypervisor::None`
implementation to instead represent an unknown (but equally valid)
hypervisor. The unknown name will now be the value of `hypervisor` in
the generated config, where it used to be `hypervisor: none`.

For example:
```bash
  $ .. centos6-64{hypervisor=custom}
```
```yaml
  ---
  HOSTS:
    centos6-64-1:
      pe_dir:
      pe_ver:
      pe_upgrade_dir:
      pe_upgrade_ver:
      platform: el-6-x86_64
      hypervisor: custom
      roles:
      - agent
  CONFIG:
    nfs_server: none
    consoleport: 443
```