### PR TITLE
(QENG-4034) Automatically URL-decode raw input

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,59 @@ CONFIG:
   custom_api: http://api.custom.net
 ```
 
+### URL-encoded input
+
+It may be necessary to URL-encode the input in order for it to properly be used
+in certain contexts, such as Jenkins.
+
+In most cases it will only be necessary to escape the characters that support
+arbitrary settings, which means the following three characters: {,}
+
+```
+$ beaker-hostgenerator centos6-64mcd-aix53-POWERfa%7Bhypervisor=aix%2Cvmhostname=pe-aix-53-acceptance.delivery.puppetlabs.net%7D
+```
+
+Is equivalent to
+
+```
+$ beaker-hostgenerator centos6-64mcd-aix53-POWERfa{hypervisor=aix,vmhostname=pe-aix-53-acceptance.delivery.puppetlabs.net}
+```
+
+And will generate
+
+```yaml
+---
+HOSTS:
+  centos6-64-1:
+    pe_dir:
+    pe_ver:
+    pe_upgrade_dir:
+    pe_upgrade_ver:
+    hypervisor: vmpooler
+    platform: el-6-x86_64
+    template: centos-6-x86_64
+    roles:
+    - agent
+    - master
+    - dashboard
+    - database
+  aix53-POWER-1:
+    pe_dir:
+    pe_ver:
+    pe_upgrade_dir:
+    pe_upgrade_ver:
+    platform: aix-5.3-power
+    hypervisor: aix
+    vmhostname: pe-aix-53-acceptance.delivery.puppetlabs.net
+    roles:
+    - agent
+    - frictionless
+CONFIG:
+  nfs_server: none
+  consoleport: 443
+  pooling_api: http://vmpooler.delivery.puppetlabs.net/
+```
+
 ## Testing
 
 Beaker Host Generator currently uses both rspec and minitest tests. To run both

--- a/lib/beaker-hostgenerator/generator.rb
+++ b/lib/beaker-hostgenerator/generator.rb
@@ -22,6 +22,7 @@ module BeakerHostGenerator
     # @returns [String] A complete YAML map as a string defining the HOSTS and
     #                   CONFIG sections as required by Beaker.
     def generate(layout, options)
+      layout = prepare_layout(layout)
       tokens = tokenize_layout(layout)
       config = {}.deep_merge(BASE_CONFIG)
       nodeid = Hash.new(1)

--- a/lib/beaker-hostgenerator/parser.rb
+++ b/lib/beaker-hostgenerator/parser.rb
@@ -1,5 +1,6 @@
 require 'beaker-hostgenerator/data'
 require 'beaker-hostgenerator/exceptions'
+require 'uri'
 
 module BeakerHostGenerator
   # Functions for parsing the raw user input host layout string and turning
@@ -10,8 +11,9 @@ module BeakerHostGenerator
   # further by other functions in this module.
   #
   # For example, given the raw user input string that defines the host layout,
-  # you would first split it into tokens via `tokenize_layout`, and then for
-  # each token you would call `is_ostype_token?` and/or `parse_node_info_token`.
+  # you would first prepare it for tokenization via `prepare_layout`, then split
+  # it into tokens via `tokenize_layout`, and then for each token you would
+  # call `is_ostype_token?` and/or `parse_node_info_token`.
   module Parser
 
     # Parses a single node definition into the following components:
@@ -64,6 +66,17 @@ module BeakerHostGenerator
     NODE_REGEX=/\A(?<bits>[A-Z0-9]+|\d+)((?<arbitrary_roles>([[:lower:]_]*|\,)*)\.)?(?<roles>[uacldfm]*)(?<host_settings>\{[[:print:]]*\})?\Z/
 
     module_function
+
+    # Prepares the host input string for tokenization, such as URL-decoding.
+    #
+    # @param layout_spec [String] Raw user input; well-formatted string
+    #                             specification of the hosts to generate.
+    #                             For example `"aix53-POWERfa%7Bhypervisor=aix%7D"`.
+    # @returns [String] Input string with transformations necessary for
+    #                   tokenization.
+    def prepare_layout(layout_spec)
+      URI.decode(layout_spec)
+    end
 
     # Breaks apart the host input string into chunks suitable for processing
     # by the generator. Returns an array of substrings of the input spec string.

--- a/spec/beaker-hostgenerator/parser_spec.rb
+++ b/spec/beaker-hostgenerator/parser_spec.rb
@@ -4,6 +4,13 @@ module BeakerHostGenerator
   describe Parser do
     include BeakerHostGenerator::Parser
 
+    describe 'prepare_layout' do
+      it 'Supports URL-encoded input' do
+        expect( prepare_layout('centos6-64m%7Bfoo=bar-baz,this=that%7D-32a') ).
+          to eq('centos6-64m{foo=bar-baz,this=that}-32a')
+      end
+    end
+
     describe 'parse_node_info_token' do
 
       it 'Raises InvalidNodeSpecError for invalid tokens.' do

--- a/test/fixtures/per-host-settings/url-encoded.yaml
+++ b/test/fixtures/per-host-settings/url-encoded.yaml
@@ -1,0 +1,44 @@
+---
+arguments_string: centos6-64mcd-aix53-POWERfa%7Bhypervisor=aix%2Cvmhostname=pe-aix-53-acceptance.delivery.puppetlabs.net%7D-POWERa%7Bfoo=bar%7D
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    centos6-64-1:
+      pe_dir:
+      pe_ver:
+      pe_upgrade_dir:
+      pe_upgrade_ver:
+      hypervisor: vmpooler
+      platform: el-6-x86_64
+      template: centos-6-x86_64
+      roles:
+      - agent
+      - master
+      - dashboard
+      - database
+    aix53-POWER-1:
+      pe_dir:
+      pe_ver:
+      pe_upgrade_dir:
+      pe_upgrade_ver:
+      platform: aix-5.3-power
+      hypervisor: aix
+      vmhostname: pe-aix-53-acceptance.delivery.puppetlabs.net
+      roles:
+      - agent
+      - frictionless
+    aix53-POWER-2:
+      pe_dir:
+      pe_ver:
+      pe_upgrade_dir:
+      pe_upgrade_ver:
+      hypervisor: vmpooler
+      platform: aix-5.3-power
+      foo: bar
+      roles:
+      - agent
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception:


### PR DESCRIPTION
This commit adds a "pre-processing" step to the Parser that will always
attempt to URL-decode the input before parsing it. This behavior is
necessary to support specifying arbitrary settings in the input string
when the input ends up as part of an HTTP URL, such as almost every
usage we currently have in Jenkins.