### PR TITLE
(QENG-4204) Add AlwaysBeScheduling hypervisor

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,10 @@ input. See the [Custom hypervisor](#custom-hypervisor) example for more
 information.
 
 It currently provides built-in configuration for Puppets' internal
-[vmpooler][vmpooler] hypervisor and static (non-provisioned) nodes, and is
-designed in a way that makes it possible to easily add support for additional
-hypervisors (any hypervisor type supported by [beaker][beaker]).
+[vmpooler][vmpooler] hypervisor, [always-be-scheduling][always-be-scheduling]
+hypervisor, static (non-provisioned) nodes, and is designed in a way that makes
+it possible to easily add support for additional hypervisors
+(any hypervisor type supported by [beaker][beaker]).
 
 To see the list of built-in hypervisors you can run:
 ```
@@ -379,3 +380,4 @@ If you have questions or comments, please contact the Beaker team at the
 [license]: LICENSE
 [contributing]: CONTRIBUTING.md
 [apache-v2]: http://www.apache.org/licenses/LICENSE-2.0.html
+[always-be-scheduling]: https://github.com/puppetlabs/always-be-scheduling

--- a/lib/beaker-hostgenerator/hypervisor.rb
+++ b/lib/beaker-hostgenerator/hypervisor.rb
@@ -45,7 +45,8 @@ module BeakerHostGenerator
     #                                                and their implementations.
     def self.builtin_hypervisors()
       {
-        'vmpooler' => BeakerHostGenerator::Hypervisor::Vmpooler
+        'vmpooler' => BeakerHostGenerator::Hypervisor::Vmpooler,
+        'abs' => BeakerHostGenerator::Hypervisor::ABS
       }
     end
 
@@ -94,3 +95,4 @@ end
 # hypervisor implementation files.
 require 'beaker-hostgenerator/hypervisor/unknown'
 require 'beaker-hostgenerator/hypervisor/vmpooler'
+require 'beaker-hostgenerator/hypervisor/abs'

--- a/lib/beaker-hostgenerator/hypervisor/abs.rb
+++ b/lib/beaker-hostgenerator/hypervisor/abs.rb
@@ -1,0 +1,31 @@
+require 'beaker-hostgenerator/data'
+require 'beaker-hostgenerator/hypervisor'
+require 'deep_merge'
+
+module BeakerHostGenerator
+  module Hypervisor
+    # AlwaysBeScheduling implementation to support CI.next.
+    #
+    # The ABS services requires the vmpooler template values as input to
+    # determine the type of platform that's being requested.
+    #
+    # Therefore, this hypervisor just reuses the vmpooler hypervisor template
+    # values, and in the future will likely contain the fake template values to
+    # use for non-vmpooler platforms like AIX.
+    class ABS < BeakerHostGenerator::Hypervisor::Interface
+      include BeakerHostGenerator::Data
+
+      def generate_node(node_info, base_config, bhg_version)
+        base_config['hypervisor'] = 'abs'
+
+        # For now, we just reuse the vmpooler data
+        platform = node_info['platform']
+        platform_info = get_platform_info(bhg_version, platform, :vmpooler)
+
+        base_config.deep_merge! platform_info
+
+        return base_config
+      end
+    end
+  end
+end

--- a/test/fixtures/per-host-settings/every-hypervisor.yaml
+++ b/test/fixtures/per-host-settings/every-hypervisor.yaml
@@ -1,5 +1,5 @@
 ---
-arguments_string: centos6-64m{hypervisor=vmpooler}-debian8-32a{hypervisor=none}
+arguments_string: centos6-64m{hypervisor=vmpooler}-debian8-32a{hypervisor=none}-redhat7-64f{hypervisor=abs}
 environment_variables: {}
 expected_hash:
   HOSTS:
@@ -23,6 +23,17 @@ expected_hash:
       hypervisor: none
       roles:
       - agent
+    redhat7-64-1:
+      pe_dir:
+      pe_ver:
+      pe_upgrade_dir:
+      pe_upgrade_ver:
+      hypervisor: abs
+      platform: el-7-x86_64
+      template: redhat-7-x86_64
+      roles:
+      - agent
+      - frictionless
   CONFIG:
     nfs_server: none
     consoleport: 443


### PR DESCRIPTION
This commit adds a new hypervisor called 'abs' that will support
generating configurations necessary for working with CI.next and the
AlwaysBeScheduling service.

Currently, the behavior of the abs hypervisor is basically the same as
the vmpooler hypervisor. The only difference is it doesn't fixup the
nodes to support old PE versions.

Having a built-in hypervisor for ABS alleviates the need for users to
manually override the hypervisor key on each node.