### PR TITLE
(QENG-4176 & QENG-4180) Add OSX 10.12 and Windows 2016

### DIFF
--- a/lib/beaker-hostgenerator/data.rb
+++ b/lib/beaker-hostgenerator/data.rb
@@ -424,6 +424,14 @@ module BeakerHostGenerator
             'template' => 'osx-1011-x86_64'
           }
         },
+        'osx1012-64' => {
+          :general => {
+            'platform' => 'osx-10.12-x86_64'
+          },
+          :vmpooler => {
+            'template' => 'osx-1012-x86_64'
+          }
+        },
         'redhat4-32' => {
           :general => {
             'platform' => 'el-4-i386'
@@ -849,6 +857,24 @@ module BeakerHostGenerator
           },
           :vmpooler => {
             'template' => 'win-2012r2-x86_64'
+          }
+        },
+        'windows2016-64' => {
+          :general => {
+            'platform' => 'windows-2016-64',
+            'ruby_arch' => 'x64'
+          },
+          :vmpooler => {
+            'template' => 'win-2016-x86_64'
+          }
+        },
+        'windows2016-6432' => {
+          :general => {
+            'platform' => 'windows-2016-64',
+            'ruby_arch' => 'x86'
+          },
+          :vmpooler => {
+            'template' => 'win-2016-x86_64'
           }
         },
         'windows7-64' => {

--- a/test/fixtures/generated/default/osx1012-64m
+++ b/test/fixtures/generated/default/osx1012-64m
@@ -1,0 +1,21 @@
+---
+arguments_string: osx1012-64m
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    osx1012-64-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      hypervisor: vmpooler
+      platform: osx-10.12-x86_64
+      template: osx-1012-x86_64
+      roles:
+      - agent
+      - master
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception: 

--- a/test/fixtures/generated/default/windows2016-6432m
+++ b/test/fixtures/generated/default/windows2016-6432m
@@ -1,0 +1,22 @@
+---
+arguments_string: windows2016-6432m
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    windows2016-6432-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      hypervisor: vmpooler
+      platform: windows-2016-64
+      ruby_arch: x86
+      template: win-2016-x86_64
+      roles:
+      - agent
+      - master
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception: 

--- a/test/fixtures/generated/default/windows2016-64f
+++ b/test/fixtures/generated/default/windows2016-64f
@@ -1,0 +1,22 @@
+---
+arguments_string: windows2016-64f
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    windows2016-64-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      hypervisor: vmpooler
+      platform: windows-2016-64
+      ruby_arch: x64
+      template: win-2016-x86_64
+      roles:
+      - agent
+      - frictionless
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception: 

--- a/test/fixtures/generated/multiplatform/centos5-64aulcdfm-windows2016-6432-centos5-64a
+++ b/test/fixtures/generated/multiplatform/centos5-64aulcdfm-windows2016-6432-centos5-64a
@@ -1,0 +1,47 @@
+---
+arguments_string: centos5-64aulcdfm-windows2016-6432-centos5-64a
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    centos5-64-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      hypervisor: vmpooler
+      platform: el-5-x86_64
+      template: centos-5-x86_64
+      roles:
+      - agent
+      - ca
+      - classifier
+      - dashboard
+      - database
+      - frictionless
+      - master
+    windows2016-6432-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      hypervisor: vmpooler
+      platform: windows-2016-64
+      ruby_arch: x86
+      template: win-2016-x86_64
+      roles:
+      - agent
+    centos5-64-2:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      hypervisor: vmpooler
+      platform: el-5-x86_64
+      template: centos-5-x86_64
+      roles:
+      - agent
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception: 

--- a/test/fixtures/generated/multiplatform/centos6-32a-windows2016-64-centos6-32aulcdfm
+++ b/test/fixtures/generated/multiplatform/centos6-32a-windows2016-64-centos6-32aulcdfm
@@ -1,0 +1,47 @@
+---
+arguments_string: centos6-32a-windows2016-64-centos6-32aulcdfm
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    centos6-32-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      hypervisor: vmpooler
+      platform: el-6-i386
+      template: centos-6-i386
+      roles:
+      - agent
+    windows2016-64-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      hypervisor: vmpooler
+      platform: windows-2016-64
+      ruby_arch: x64
+      template: win-2016-x86_64
+      roles:
+      - agent
+    centos6-32-2:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      hypervisor: vmpooler
+      platform: el-6-i386
+      template: centos-6-i386
+      roles:
+      - agent
+      - ca
+      - classifier
+      - dashboard
+      - database
+      - frictionless
+      - master
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception: 

--- a/test/fixtures/generated/multiplatform/osx1012-64m-sles10-32-osx1012-64u
+++ b/test/fixtures/generated/multiplatform/osx1012-64m-sles10-32-osx1012-64u
@@ -1,0 +1,42 @@
+---
+arguments_string: osx1012-64m-sles10-32-osx1012-64u
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    osx1012-64-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      hypervisor: vmpooler
+      platform: osx-10.12-x86_64
+      template: osx-1012-x86_64
+      roles:
+      - agent
+      - master
+    sles10-32-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      hypervisor: vmpooler
+      platform: sles-10-i386
+      template: sles-10-i386
+      roles:
+      - agent
+    osx1012-64-2:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      hypervisor: vmpooler
+      platform: osx-10.12-x86_64
+      template: osx-1012-x86_64
+      roles:
+      - agent
+      - ca
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception: 

--- a/test/fixtures/generated/multiplatform/osx1012-64m-sles11-32-osx1012-64u
+++ b/test/fixtures/generated/multiplatform/osx1012-64m-sles11-32-osx1012-64u
@@ -1,0 +1,42 @@
+---
+arguments_string: osx1012-64m-sles11-32-osx1012-64u
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    osx1012-64-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      hypervisor: vmpooler
+      platform: osx-10.12-x86_64
+      template: osx-1012-x86_64
+      roles:
+      - agent
+      - master
+    sles11-32-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      hypervisor: vmpooler
+      platform: sles-11-i386
+      template: sles-11-i386
+      roles:
+      - agent
+    osx1012-64-2:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      hypervisor: vmpooler
+      platform: osx-10.12-x86_64
+      template: osx-1012-x86_64
+      roles:
+      - agent
+      - ca
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception: 

--- a/test/fixtures/generated/multiplatform/sles10-32f-osx1012-64-sles10-32l
+++ b/test/fixtures/generated/multiplatform/sles10-32f-osx1012-64-sles10-32l
@@ -1,0 +1,42 @@
+---
+arguments_string: sles10-32f-osx1012-64-sles10-32l
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    sles10-32-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      hypervisor: vmpooler
+      platform: sles-10-i386
+      template: sles-10-i386
+      roles:
+      - agent
+      - frictionless
+    osx1012-64-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      hypervisor: vmpooler
+      platform: osx-10.12-x86_64
+      template: osx-1012-x86_64
+      roles:
+      - agent
+    sles10-32-2:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      hypervisor: vmpooler
+      platform: sles-10-i386
+      template: sles-10-i386
+      roles:
+      - agent
+      - classifier
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception: 

--- a/test/fixtures/generated/multiplatform/sles11-32aulcdfm-osx1012-64-sles11-32a
+++ b/test/fixtures/generated/multiplatform/sles11-32aulcdfm-osx1012-64-sles11-32a
@@ -1,0 +1,46 @@
+---
+arguments_string: sles11-32aulcdfm-osx1012-64-sles11-32a
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    sles11-32-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      hypervisor: vmpooler
+      platform: sles-11-i386
+      template: sles-11-i386
+      roles:
+      - agent
+      - ca
+      - classifier
+      - dashboard
+      - database
+      - frictionless
+      - master
+    osx1012-64-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      hypervisor: vmpooler
+      platform: osx-10.12-x86_64
+      template: osx-1012-x86_64
+      roles:
+      - agent
+    sles11-32-2:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      hypervisor: vmpooler
+      platform: sles-11-i386
+      template: sles-11-i386
+      roles:
+      - agent
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception: 

--- a/test/fixtures/generated/multiplatform/windows2016-6432m-centos5-64-windows2016-6432u
+++ b/test/fixtures/generated/multiplatform/windows2016-6432m-centos5-64-windows2016-6432u
@@ -1,0 +1,44 @@
+---
+arguments_string: windows2016-6432m-centos5-64-windows2016-6432u
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    windows2016-6432-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      hypervisor: vmpooler
+      platform: windows-2016-64
+      ruby_arch: x86
+      template: win-2016-x86_64
+      roles:
+      - agent
+      - master
+    centos5-64-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      hypervisor: vmpooler
+      platform: el-5-x86_64
+      template: centos-5-x86_64
+      roles:
+      - agent
+    windows2016-6432-2:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      hypervisor: vmpooler
+      platform: windows-2016-64
+      ruby_arch: x86
+      template: win-2016-x86_64
+      roles:
+      - agent
+      - ca
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception: 

--- a/test/fixtures/generated/multiplatform/windows2016-64f-centos6-32-windows2016-64l
+++ b/test/fixtures/generated/multiplatform/windows2016-64f-centos6-32-windows2016-64l
@@ -1,0 +1,44 @@
+---
+arguments_string: windows2016-64f-centos6-32-windows2016-64l
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    windows2016-64-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      hypervisor: vmpooler
+      platform: windows-2016-64
+      ruby_arch: x64
+      template: win-2016-x86_64
+      roles:
+      - agent
+      - frictionless
+    centos6-32-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      hypervisor: vmpooler
+      platform: el-6-i386
+      template: centos-6-i386
+      roles:
+      - agent
+    windows2016-64-2:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      hypervisor: vmpooler
+      platform: windows-2016-64
+      ruby_arch: x64
+      template: win-2016-x86_64
+      roles:
+      - agent
+      - classifier
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception: 

--- a/test/fixtures/generated/osinfo-version-0/osx1012-64m
+++ b/test/fixtures/generated/osinfo-version-0/osx1012-64m
@@ -1,0 +1,21 @@
+---
+arguments_string: "--osinfo-version 0 osx1012-64m"
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    osx1012-64-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      hypervisor: vmpooler
+      platform: osx-10.12-x86_64
+      template: osx-1012-x86_64
+      roles:
+      - agent
+      - master
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception: 

--- a/test/fixtures/generated/osinfo-version-0/windows2016-6432m
+++ b/test/fixtures/generated/osinfo-version-0/windows2016-6432m
@@ -1,0 +1,22 @@
+---
+arguments_string: "--osinfo-version 0 windows2016-6432m"
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    windows2016-6432-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      hypervisor: vmpooler
+      platform: windows-2016-64
+      ruby_arch: x86
+      template: win-2016-x86_64
+      roles:
+      - agent
+      - master
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception: 

--- a/test/fixtures/generated/osinfo-version-0/windows2016-64f
+++ b/test/fixtures/generated/osinfo-version-0/windows2016-64f
@@ -1,0 +1,22 @@
+---
+arguments_string: "--osinfo-version 0 windows2016-64f"
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    windows2016-64-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      hypervisor: vmpooler
+      platform: windows-2016-64
+      ruby_arch: x64
+      template: win-2016-x86_64
+      roles:
+      - agent
+      - frictionless
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception: 

--- a/test/fixtures/generated/osinfo-version-1/osx1012-64m
+++ b/test/fixtures/generated/osinfo-version-1/osx1012-64m
@@ -1,0 +1,21 @@
+---
+arguments_string: "--osinfo-version 1 osx1012-64m"
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    osx1012-64-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      hypervisor: vmpooler
+      platform: osx-10.12-x86_64
+      template: osx-1012-x86_64
+      roles:
+      - agent
+      - master
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception: 

--- a/test/fixtures/generated/osinfo-version-1/windows2016-6432m
+++ b/test/fixtures/generated/osinfo-version-1/windows2016-6432m
@@ -1,0 +1,22 @@
+---
+arguments_string: "--osinfo-version 1 windows2016-6432m"
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    windows2016-6432-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      hypervisor: vmpooler
+      platform: windows-2016-64
+      ruby_arch: x86
+      template: win-2016-x86_64
+      roles:
+      - agent
+      - master
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception: 

--- a/test/fixtures/generated/osinfo-version-1/windows2016-64f
+++ b/test/fixtures/generated/osinfo-version-1/windows2016-64f
@@ -1,0 +1,22 @@
+---
+arguments_string: "--osinfo-version 1 windows2016-64f"
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    windows2016-64-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      hypervisor: vmpooler
+      platform: windows-2016-64
+      ruby_arch: x64
+      template: win-2016-x86_64
+      roles:
+      - agent
+      - frictionless
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception: 


### PR DESCRIPTION
Added OSX 10.12 (Sierra) and Windows Server 2016 to supported beaker-hostgenerator platforms