### PR TITLE
(QENG-4204) Add CLI flag to only generate templates

### DIFF
--- a/lib/beaker-hostgenerator/abs-support.rb
+++ b/lib/beaker-hostgenerator/abs-support.rb
@@ -1,0 +1,15 @@
+module BeakerHostGenerator
+  # Utility functions for supporting CI.next and the AlwaysBeScheduling hypervisor.
+  module AbsSupport
+    module_function
+
+    # Given an existing, fully-specified host configuration, extract only the
+    # template values from each host and return them as a comma-separated
+    # string such as: "centos-6-x86_64=1,redhat-7-x86_64=1"
+    def extract_templates(config)
+      config['HOSTS'].map do |host, settings|
+        "#{settings['template']}=1"
+      end.join(',')
+    end
+  end
+end

--- a/lib/beaker-hostgenerator/cli.rb
+++ b/lib/beaker-hostgenerator/cli.rb
@@ -2,7 +2,9 @@ require 'beaker-hostgenerator/generator'
 require 'beaker-hostgenerator/hypervisor'
 require 'beaker-hostgenerator/roles'
 require 'beaker-hostgenerator/version'
+require 'beaker-hostgenerator/abs-support'
 require 'optparse'
+require 'yaml'
 
 module BeakerHostGenerator
   class CLI
@@ -64,6 +66,11 @@ Usage: beaker-hostgenerator [options] <layout>
                 'List beaker-hostgenerator supported platforms, roles, and hypervisors. ' <<
                 'Does not produce host config.') do
           @options[:list_supported_values] = true
+        end
+
+        opts.on('--templates-only',
+               'Generate a reduced output including only the templates from each host.') do
+          @options[:templates_only] = true
         end
 
         opts.on('-t',
@@ -144,9 +151,13 @@ Usage: beaker-hostgenerator [options] <layout>
         BeakerHostGenerator::Version::STRING
       elsif @options[:list_supported_values]
         supported_values_help_text
+      elsif @options[:templates_only]
+        config = BeakerHostGenerator::Generator.new.generate(@layout, @options)
+        BeakerHostGenerator::AbsSupport.extract_templates(config)
       else
         print_warnings
-        BeakerHostGenerator::Generator.new.generate(@layout, @options)
+        config = BeakerHostGenerator::Generator.new.generate(@layout, @options)
+        config.to_yaml
       end
     end
 

--- a/lib/beaker-hostgenerator/generator.rb
+++ b/lib/beaker-hostgenerator/generator.rb
@@ -3,24 +3,22 @@ require 'beaker-hostgenerator/roles'
 require 'beaker-hostgenerator/hypervisor'
 require 'beaker-hostgenerator/parser'
 
-require 'yaml'
-
 module BeakerHostGenerator
   class Generator
     include BeakerHostGenerator::Data
     include BeakerHostGenerator::Parser
     include BeakerHostGenerator::Roles
 
-    # Main host generation entry point, returns a YAML map as a string for the
-    # given host specification and optional configuration.
+    # Main host generation entry point, returns a Ruby map for the given host
+    # specification and optional configuration.
     #
     # @param layout [String] The raw hosts specification user input.
     #                        For example `"centos6-64m-redhat7-64a"`.
     # @param options [Hash] Global, optional configuration such as the default
     #                       hypervisor or OS info version.
     #
-    # @returns [String] A complete YAML map as a string defining the HOSTS and
-    #                   CONFIG sections as required by Beaker.
+    # @returns [Hash] A complete Ruby map as defining the HOSTS and CONFIG
+    #                 sections as required by Beaker.
     def generate(layout, options)
       layout = prepare_layout(layout)
       tokens = tokenize_layout(layout)
@@ -82,7 +80,7 @@ module BeakerHostGenerator
       # Munge non-string scalar values into proper data types
       unstringify_values!(config)
 
-      return config.to_yaml
+      return config
     end
 
     def get_host_roles(node_info)

--- a/spec/beaker-hostgenerator/abs-support_spec.rb
+++ b/spec/beaker-hostgenerator/abs-support_spec.rb
@@ -1,0 +1,13 @@
+require 'beaker-hostgenerator/cli'
+
+module BeakerHostGenerator
+  describe AbsSupport do
+    describe 'extract_templates' do
+      it 'Returns a simple CSV string with template counts' do
+        input = ['--templates-only', 'centos6-64m-centos6-64m-redhat7-64m']
+        expect( BeakerHostGenerator::CLI.new(input).execute ).
+          to eq('centos-6-x86_64=1,centos-6-x86_64=1,redhat-7-x86_64=1')
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds a CLI switch '--templates-only' that will reduce the generated
output to include only the template values from the HOSTS.