### PR TITLE
Merge CI.next branch into master

### DIFF
--- a/lib/beaker-hostgenerator/abs-support.rb
+++ b/lib/beaker-hostgenerator/abs-support.rb
@@ -3,13 +3,28 @@ module BeakerHostGenerator
   module AbsSupport
     module_function
 
-    # Given an existing, fully-specified host configuration, extract only the
-    # template values from each host and return them as a comma-separated
-    # string such as: "centos-6-x86_64=1,redhat-7-x86_64=1"
+    # Given an existing, fully-specified host configuration, count the number of
+    # hosts using each template, and return a map of template name to host count.
+    #
+    # For example, given the following config (parts omitted for brevity):
+    #    {"HOSTS"=>
+    #     {"centos6-64-1"=>
+    #        {"template"=>"centos-6-x86_64", ...},
+    #      "redhat7-64-1"=>
+    #        {"template"=>"redhat-7-x86_64", ...},
+    #      "centos6-64-2"=>
+    #        {"template"=>"centos-6-x86_64", ...}},
+    #     ...
+    #    }}
+    #
+    # Returns the following map:
+    #     {"centos-6-x86_64"=>2, "redhat-7-x86_64"=>1}
+    #
     def extract_templates(config)
-      config['HOSTS'].map do |host, settings|
-        "#{settings['template']}=1"
-      end.join(',')
+      templates_hosts = config['HOSTS'].values.group_by { |h| h['template'] }
+      templates_hosts.each do |template, hosts|
+        templates_hosts[template] = hosts.count
+      end
     end
   end
 end

--- a/lib/beaker-hostgenerator/cli.rb
+++ b/lib/beaker-hostgenerator/cli.rb
@@ -152,8 +152,10 @@ Usage: beaker-hostgenerator [options] <layout>
       elsif @options[:list_supported_values]
         supported_values_help_text
       elsif @options[:templates_only]
+        require 'json'
         config = BeakerHostGenerator::Generator.new.generate(@layout, @options)
-        BeakerHostGenerator::AbsSupport.extract_templates(config)
+        templates = BeakerHostGenerator::AbsSupport.extract_templates(config)
+        templates.to_json
       else
         print_warnings
         config = BeakerHostGenerator::Generator.new.generate(@layout, @options)

--- a/spec/beaker-hostgenerator/abs-support_spec.rb
+++ b/spec/beaker-hostgenerator/abs-support_spec.rb
@@ -1,12 +1,13 @@
 require 'beaker-hostgenerator/cli'
+require 'json'
 
 module BeakerHostGenerator
   describe AbsSupport do
     describe 'extract_templates' do
-      it 'Returns a simple CSV string with template counts' do
+      it 'Returns a JSON map with template counts' do
         input = ['--templates-only', 'centos6-64m-centos6-64m-redhat7-64m']
-        expect( BeakerHostGenerator::CLI.new(input).execute ).
-          to eq('centos-6-x86_64=1,centos-6-x86_64=1,redhat-7-x86_64=1')
+        expect( JSON.load(BeakerHostGenerator::CLI.new(input).execute) ).
+          to eq({"centos-6-x86_64" => 2, "redhat-7-x86_64" => 1})
       end
     end
   end


### PR DESCRIPTION
We've been using these `cinext` branch changes for a few weeks now during CI.next development.

We're ready to merge into `master` and cut a gem release so we can stop pinning projects to the `cinext` branch on GitHub and just have them depend on the new gem release like normal.