### PR TITLE
(BKR-934) Allow for whitespace in settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,11 +227,12 @@ It may be necessary to URL-encode the input in order for it to properly be used
 in certain contexts, such as Jenkins.
 
 In most cases it will only be necessary to escape the characters that support
-arbitrary settings, which means the following three characters:
+arbitrary settings, which means the following four characters:
 
 - `{` is `%7B`
 - `,` is `%2C`
 - `}` is `%7D`
+- ` ` is `%20`
 
 For a full URL encoding reference see: http://www.w3schools.com/tags/ref_urlencode.asp
 

--- a/lib/beaker-hostgenerator/generator.rb
+++ b/lib/beaker-hostgenerator/generator.rb
@@ -20,7 +20,7 @@ module BeakerHostGenerator
     # @returns [Hash] A complete Ruby map as defining the HOSTS and CONFIG
     #                 sections as required by Beaker.
     def generate(layout, options)
-      layout = prepare_layout(layout)
+      layout = prepare(layout)
       tokens = tokenize_layout(layout)
       config = {}.deep_merge(BASE_CONFIG)
       nodeid = Hash.new(1)
@@ -29,7 +29,8 @@ module BeakerHostGenerator
 
       # Merge in global configuration settings
       if options[:global_config]
-        global_config = settings_string_to_map(options[:global_config])
+        decoded = prepare(options[:global_config])
+        global_config = settings_string_to_map(decoded)
         config['CONFIG'].deep_merge!(global_config)
       end
 

--- a/lib/beaker-hostgenerator/parser.rb
+++ b/lib/beaker-hostgenerator/parser.rb
@@ -11,9 +11,9 @@ module BeakerHostGenerator
   # further by other functions in this module.
   #
   # For example, given the raw user input string that defines the host layout,
-  # you would first prepare it for tokenization via `prepare_layout`, then split
-  # it into tokens via `tokenize_layout`, and then for each token you would
-  # call `is_ostype_token?` and/or `parse_node_info_token`.
+  # you would first prepare it for tokenization via `prepare`, then split it
+  # into tokens via `tokenize_layout`, and then for each token you would call
+  # `is_ostype_token?` and/or `parse_node_info_token`.
   module Parser
 
     # Parses a single node definition into the following components:
@@ -69,13 +69,13 @@ module BeakerHostGenerator
 
     # Prepares the host input string for tokenization, such as URL-decoding.
     #
-    # @param layout_spec [String] Raw user input; well-formatted string
-    #                             specification of the hosts to generate.
-    #                             For example `"aix53-POWERfa%7Bhypervisor=aix%7D"`.
+    # @param spec [String] Raw user input; well-formatted string specification
+    #                      of the hosts to generate.
+    #                      For example `"aix53-POWERfa%7Bhypervisor=aix%7D"`.
     # @returns [String] Input string with transformations necessary for
     #                   tokenization.
-    def prepare_layout(layout_spec)
-      URI.decode(layout_spec)
+    def prepare(spec)
+      URI.decode(spec)
     end
 
     # Breaks apart the host input string into chunks suitable for processing
@@ -198,7 +198,8 @@ module BeakerHostGenerator
     # configuration.
     #
     # The string is expected to be of the form "{key1=value1,key2=value2,...}".
-    # Any whitespace found in the string will be stripped and ignored.
+    # Whitespace is expected to be properly quoted as it will not be treated
+    # any different than non-whitespace characters.
     #
     # Throws an exception of the string is malformed in any way.
     #
@@ -211,7 +212,6 @@ module BeakerHostGenerator
       settings_pairs =
         host_settings.
         delete('{}').
-        gsub(' ', '').
         split(',').
         map { |keyvalue| keyvalue.split('=') }
 

--- a/spec/beaker-hostgenerator/parser_spec.rb
+++ b/spec/beaker-hostgenerator/parser_spec.rb
@@ -4,9 +4,9 @@ module BeakerHostGenerator
   describe Parser do
     include BeakerHostGenerator::Parser
 
-    describe 'prepare_layout' do
+    describe 'prepare' do
       it 'Supports URL-encoded input' do
-        expect( prepare_layout('centos6-64m%7Bfoo=bar-baz,this=that%7D-32a') ).
+        expect( prepare('centos6-64m%7Bfoo=bar-baz,this=that%7D-32a') ).
           to eq('centos6-64m{foo=bar-baz,this=that}-32a')
       end
     end
@@ -113,17 +113,16 @@ module BeakerHostGenerator
       end
 
       context 'When using arbitrary host settings' do
-        it 'Supports arbitrary whitespace' do
-          expect( parse_node_info_token("64{ k1=v1, k2=v2,  k3 = v3 ,  k4  =v4  }") ).
+        it 'Supports arbitrary whitespace in values' do
+          expect( parse_node_info_token("64{k1=value 1,k2=v2,k3=  v3  }") ).
             to eq({
                     "roles" => "",
                     "arbitrary_roles" => [],
                     "bits" => "64",
                     "host_settings" => {
-                      "k1" => "v1",
+                      "k1" => "value 1",
                       "k2" => "v2",
-                      "k3" => "v3",
-                      "k4" => "v4"
+                      "k3" => "  v3  "
                     }
                   })
         end

--- a/test/fixtures/per-host-settings/with-global-settings.yaml
+++ b/test/fixtures/per-host-settings/with-global-settings.yaml
@@ -1,5 +1,5 @@
 ---
-arguments_string: "--global-config {masterless=true,number=1234} redhat7-64c{type=o-negative}"
+arguments_string: "--global-config {masterless=true,number=1234,key=url%20encoded%20%20white%20space} redhat7-64c{type=o-negative}"
 environment_variables: {}
 expected_hash:
   HOSTS:
@@ -20,5 +20,6 @@ expected_hash:
     consoleport: 443
     masterless: true
     number: 1234
+    key: url encoded  white space
     pooling_api: http://vmpooler.delivery.puppetlabs.net/
 expected_exception:


### PR DESCRIPTION
Previously all whitespace was automatically removed from all input. This
commit removes that behavior, allowing for values with whitespace in
them to be properly generated.

This change means users are responsible for properly quoting, escaping,
or URL-encoding the whitespace as necessary.