### PR TITLE
(MAINT) Exclude test files from built gem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ junit
 acceptance-tests
 pkg
 Gemfile.lock
+Gemfile.local
 options.rb
 test.cfg
 .yardoc

--- a/beaker-hostgenerator.gemspec
+++ b/beaker-hostgenerator.gemspec
@@ -17,7 +17,7 @@ eos
   s.license     = 'Apache2'
 
   s.files         = `git ls-files`.split("\n")
-  s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
+  s.test_files    = `git ls-files -- {test,spec}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 

--- a/beaker-hostgenerator.gemspec
+++ b/beaker-hostgenerator.gemspec
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 $LOAD_PATH.unshift File.expand_path("../lib", __FILE__)
 require 'beaker-hostgenerator/version'
 

--- a/beaker-hostgenerator.gemspec
+++ b/beaker-hostgenerator.gemspec
@@ -16,7 +16,7 @@ eos
   s.description = %q{For use for the Beaker acceptance testing tool}
   s.license     = 'Apache2'
 
-  s.files         = `git ls-files`.split("\n")
+  s.files         = `git ls-files`.split("\n").reject { |f| f.match(/^(test|spec|acceptance)/) }
   s.test_files    = `git ls-files -- {test,spec}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]


### PR DESCRIPTION
This project has a TON of test fixtures that are not necessary in production,
yet we were still bundling them into the gem.

We don't need to include any of these, they were just making the resulting gem
significantly larger.