### PR TITLE
(MAINT) Delete test_files directive to keep fixtures out of the gem

### DIFF
--- a/beaker-hostgenerator.gemspec
+++ b/beaker-hostgenerator.gemspec
@@ -17,7 +17,6 @@ eos
   s.license     = 'Apache2'
 
   s.files         = `git ls-files`.split("\n").reject { |f| f.match(/^(test|spec|acceptance)/) }
-  s.test_files    = `git ls-files -- {test,spec}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 


### PR DESCRIPTION
This gemspec directive `test_files` will cause the files it references to be
included in the built gem so they can be used during the `gem test` command.

We do not intend to support the ability for users to run `gem test`, and
furthermore this gem subcommand doesn't even exist anymore.