### PR TITLE
(MAINT) Remove acceptance testing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,12 +2,6 @@ source ENV['GEM_SOURCE'] || "https://rubygems.org"
 
 gemspec
 
-
-group :testing do
-  gem "minitest"
-end
-
-
 if File.exists? "#{__FILE__}.local"
   eval(File.read("#{__FILE__}.local"), binding)
 end

--- a/Gemfile
+++ b/Gemfile
@@ -3,24 +3,6 @@ source ENV['GEM_SOURCE'] || "https://rubygems.org"
 gemspec
 
 
-
-def location_for(place, fake_version = nil)
-  if place =~ /^(git:[^#]*)#(.*)/
-    [fake_version, { :git => $1, :branch => $2, :require => false }].compact
-  elsif place =~ /^file:\/\/(.*)/
-    ['>= 0', { :path => File.expand_path($1), :require => false }]
-  else
-    [place, { :require => false }]
-  end
-end
-
-
-# We don't put beaker in as a test dependency because we
-# don't want to create a transitive dependency
-group :acceptance_testing do
-  gem "beaker", *location_for(ENV['BEAKER_VERSION'] || '~> 2.0')
-end
-
 group :testing do
   gem "minitest"
 end

--- a/Rakefile
+++ b/Rakefile
@@ -30,22 +30,6 @@ namespace :test do
 
   end
 
-  namespace :acceptance do
-
-    desc <<-EOS
-A quick acceptance test, named because it has no pre-suites to run
-    EOS
-    task :quick do
-
-      sh("beaker",
-         "--hosts", ENV['CONFIG'] || "acceptance/config/nodes/vagrant-ubuntu-1404.yml",
-         "--tests", "acceptance/tests",
-         "--log-level", "debug",
-         "--keyfile", ENV['KEY'] || "#{ENV['HOME']}/.ssh/id_rsa")
-    end
-
-  end
-
 end
 
 namespace :generate do
@@ -67,7 +51,6 @@ end
 # these are the default tasks invoked when only the namespace is referenced.
 # they're needed because `task :default` in those blocks doesn't work as expected.
 task 'test:spec' => ['test:spec:run', 'test:spec:minitest']
-task 'test:acceptance' => 'test:acceptance:quick'
 
 # global defaults
 task :test => 'test:spec'

--- a/acceptance/config/nodes/vagrant-ubuntu-1404.yml
+++ b/acceptance/config/nodes/vagrant-ubuntu-1404.yml
@@ -1,8 +1,0 @@
-HOSTS:
-  ubuntu-server-1404-x64:
-    roles:
-      - master
-    platform: ubuntu-14.04-amd64
-    box: puppetlabs/ubuntu-14.04-64-nocm
-    box_url: https://vagrantcloud.com/puppetlabs/boxes/ubuntu-14.04-64-nocm
-    hypervisor: vagrant

--- a/acceptance/tests/first.rb
+++ b/acceptance/tests/first.rb
@@ -1,8 +1,0 @@
-
-# Acceptance level testing goes into files in the tests directory like this one,
-# Each file corresponding to a new test made up of individual testing steps
-test_name "Template Acceptance Test Example"
-
-step "Fail fast!"
-
-fail_test("There are no acceptance tests yet!")

--- a/beaker-hostgenerator.gemspec
+++ b/beaker-hostgenerator.gemspec
@@ -16,7 +16,7 @@ eos
   s.description = %q{For use for the Beaker acceptance testing tool}
   s.license     = 'Apache2'
 
-  s.files         = `git ls-files`.split("\n").reject { |f| f.match(/^(test|spec|acceptance)/) }
+  s.files         = `git ls-files`.split("\n").reject { |f| f.match(/^(test|spec)/) }
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 

--- a/beaker-hostgenerator.gemspec
+++ b/beaker-hostgenerator.gemspec
@@ -21,6 +21,7 @@ eos
   s.require_paths = ["lib"]
 
   # Testing dependencies
+  s.add_development_dependency 'minitest'
   s.add_development_dependency 'rspec', '~> 3.0'
   s.add_development_dependency 'rspec-its'
   s.add_development_dependency 'fakefs', '~> 0.6'


### PR DESCRIPTION
This deletes everything related to acceptance testing.

We had no tests, and we have no intentions of adding any. We started to lay out
the groundwork for acceptance testing a while ago with the "acceptance/"
directory, `beaker` test dependency, and the `acceptance` Rake task.

This commit deletes that groundwork, as it is out of date and just getting in
the way at this point.  If we decide to add acceptance tests in the future, it
will likely look different than this anyway.