### PR TITLE
Add Fedora 25 platforms and test fixtures

### DIFF
--- a/lib/beaker-hostgenerator/data.rb
+++ b/lib/beaker-hostgenerator/data.rb
@@ -339,6 +339,22 @@ module BeakerHostGenerator
             'template' => 'fedora-24-x86_64'
           }
         },
+        'fedora25-32' => {
+          :general => {
+            'platform' => 'fedora-25-i386'
+          },
+          :vmpooler => {
+            'template' => 'fedora-25-i386'
+          }
+        },
+        'fedora25-64' => {
+          :general => {
+            'platform' => 'fedora-25-x86_64'
+          },
+          :vmpooler => {
+            'template' => 'fedora-25-x86_64'
+          }
+        },
         'huaweios6-POWER' => {
           :general => {
             'platform' => 'huaweios-6-powerpc'

--- a/test/fixtures/generated/default/fedora25-32c
+++ b/test/fixtures/generated/default/fedora25-32c
@@ -1,0 +1,21 @@
+---
+arguments_string: fedora25-32c
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    fedora25-32-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      hypervisor: vmpooler
+      platform: fedora-25-i386
+      template: fedora-25-i386
+      roles:
+      - agent
+      - dashboard
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception: 

--- a/test/fixtures/generated/default/fedora25-64d
+++ b/test/fixtures/generated/default/fedora25-64d
@@ -1,0 +1,21 @@
+---
+arguments_string: fedora25-64d
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    fedora25-64-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      hypervisor: vmpooler
+      platform: fedora-25-x86_64
+      template: fedora-25-x86_64
+      roles:
+      - agent
+      - database
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception: 

--- a/test/fixtures/generated/multiplatform/fedora25-32c-ubuntu1004-32-fedora25-32d
+++ b/test/fixtures/generated/multiplatform/fedora25-32c-ubuntu1004-32-fedora25-32d
@@ -1,0 +1,42 @@
+---
+arguments_string: fedora25-32c-ubuntu1004-32-fedora25-32d
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    fedora25-32-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      hypervisor: vmpooler
+      platform: fedora-25-i386
+      template: fedora-25-i386
+      roles:
+      - agent
+      - dashboard
+    ubuntu1004-32-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      hypervisor: vmpooler
+      platform: ubuntu-10.04-i386
+      template: ubuntu-1004-i386
+      roles:
+      - agent
+    fedora25-32-2:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      hypervisor: vmpooler
+      platform: fedora-25-i386
+      template: fedora-25-i386
+      roles:
+      - agent
+      - database
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception: 

--- a/test/fixtures/generated/multiplatform/fedora25-64d-solaris112-64-fedora25-64c
+++ b/test/fixtures/generated/multiplatform/fedora25-64d-solaris112-64-fedora25-64c
@@ -1,0 +1,42 @@
+---
+arguments_string: fedora25-64d-solaris112-64-fedora25-64c
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    fedora25-64-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      hypervisor: vmpooler
+      platform: fedora-25-x86_64
+      template: fedora-25-x86_64
+      roles:
+      - agent
+      - database
+    solaris112-64-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      hypervisor: vmpooler
+      platform: solaris-11.2-i386
+      template: solaris-112-x86_64
+      roles:
+      - agent
+    fedora25-64-2:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      hypervisor: vmpooler
+      platform: fedora-25-x86_64
+      template: fedora-25-x86_64
+      roles:
+      - agent
+      - dashboard
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception: 

--- a/test/fixtures/generated/multiplatform/solaris112-64f-fedora25-64-solaris112-64l
+++ b/test/fixtures/generated/multiplatform/solaris112-64f-fedora25-64-solaris112-64l
@@ -1,0 +1,42 @@
+---
+arguments_string: solaris112-64f-fedora25-64-solaris112-64l
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    solaris112-64-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      hypervisor: vmpooler
+      platform: solaris-11.2-i386
+      template: solaris-112-x86_64
+      roles:
+      - agent
+      - frictionless
+    fedora25-64-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      hypervisor: vmpooler
+      platform: fedora-25-x86_64
+      template: fedora-25-x86_64
+      roles:
+      - agent
+    solaris112-64-2:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      hypervisor: vmpooler
+      platform: solaris-11.2-i386
+      template: solaris-112-x86_64
+      roles:
+      - agent
+      - classifier
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception: 

--- a/test/fixtures/generated/multiplatform/ubuntu1004-32m-fedora25-32-ubuntu1004-32u
+++ b/test/fixtures/generated/multiplatform/ubuntu1004-32m-fedora25-32-ubuntu1004-32u
@@ -1,0 +1,42 @@
+---
+arguments_string: ubuntu1004-32m-fedora25-32-ubuntu1004-32u
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    ubuntu1004-32-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      hypervisor: vmpooler
+      platform: ubuntu-10.04-i386
+      template: ubuntu-1004-i386
+      roles:
+      - agent
+      - master
+    fedora25-32-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      hypervisor: vmpooler
+      platform: fedora-25-i386
+      template: fedora-25-i386
+      roles:
+      - agent
+    ubuntu1004-32-2:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      hypervisor: vmpooler
+      platform: ubuntu-10.04-i386
+      template: ubuntu-1004-i386
+      roles:
+      - agent
+      - ca
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception: 

--- a/test/fixtures/generated/osinfo-version-0/fedora25-32c
+++ b/test/fixtures/generated/osinfo-version-0/fedora25-32c
@@ -1,0 +1,21 @@
+---
+arguments_string: "--osinfo-version 0 fedora25-32c"
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    fedora25-32-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      hypervisor: vmpooler
+      platform: fedora-25-i386
+      template: fedora-25-i386
+      roles:
+      - agent
+      - dashboard
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception: 

--- a/test/fixtures/generated/osinfo-version-0/fedora25-64d
+++ b/test/fixtures/generated/osinfo-version-0/fedora25-64d
@@ -1,0 +1,21 @@
+---
+arguments_string: "--osinfo-version 0 fedora25-64d"
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    fedora25-64-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      hypervisor: vmpooler
+      platform: fedora-25-x86_64
+      template: fedora-25-x86_64
+      roles:
+      - agent
+      - database
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception: 

--- a/test/fixtures/generated/osinfo-version-1/fedora25-32c
+++ b/test/fixtures/generated/osinfo-version-1/fedora25-32c
@@ -1,0 +1,21 @@
+---
+arguments_string: "--osinfo-version 1 fedora25-32c"
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    fedora25-32-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      hypervisor: vmpooler
+      platform: fedora-25-i386
+      template: fedora-25-i386
+      roles:
+      - agent
+      - dashboard
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception: 

--- a/test/fixtures/generated/osinfo-version-1/fedora25-64d
+++ b/test/fixtures/generated/osinfo-version-1/fedora25-64d
@@ -1,0 +1,21 @@
+---
+arguments_string: "--osinfo-version 1 fedora25-64d"
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    fedora25-64-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      hypervisor: vmpooler
+      platform: fedora-25-x86_64
+      template: fedora-25-x86_64
+      roles:
+      - agent
+      - database
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception: 


### PR DESCRIPTION
Added fedora 25 platforms for i386 and x86_64. The test fixtures were created by running rake generate:fixtures.