### PR TITLE
Add Ubuntu 16.10 platforms and test fixtures

### DIFF
--- a/lib/beaker-hostgenerator/data.rb
+++ b/lib/beaker-hostgenerator/data.rb
@@ -758,6 +758,22 @@ module BeakerHostGenerator
             'template' => 'ubuntu-1604-x86_64'
           }
         },
+        'ubuntu1610-32' => {
+          :general => {
+            'platform' => 'ubuntu-16.10-i386'
+          },
+          :vmpooler => {
+            'template' => 'ubuntu-1610-i386'
+          }
+        },
+        'ubuntu1610-64' => {
+          :general => {
+            'platform' => 'ubuntu-16.10-amd64'
+          },
+          :vmpooler => {
+            'template' => 'ubuntu-1610-x86_64'
+          }
+        },
         'windows2003-64' => {
           :general => {
             'platform' => 'windows-2003-64',

--- a/test/fixtures/generated/default/ubuntu1610-32l
+++ b/test/fixtures/generated/default/ubuntu1610-32l
@@ -1,0 +1,21 @@
+---
+arguments_string: ubuntu1610-32l
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    ubuntu1610-32-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      hypervisor: vmpooler
+      platform: ubuntu-16.10-i386
+      template: ubuntu-1610-i386
+      roles:
+      - agent
+      - classifier
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception: 

--- a/test/fixtures/generated/default/ubuntu1610-64c
+++ b/test/fixtures/generated/default/ubuntu1610-64c
@@ -1,0 +1,21 @@
+---
+arguments_string: ubuntu1610-64c
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    ubuntu1610-64-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      hypervisor: vmpooler
+      platform: ubuntu-16.10-amd64
+      template: ubuntu-1610-x86_64
+      roles:
+      - agent
+      - dashboard
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception: 

--- a/test/fixtures/generated/multiplatform/fedora19-64a-ubuntu1610-64-fedora19-64aulcdfm
+++ b/test/fixtures/generated/multiplatform/fedora19-64a-ubuntu1610-64-fedora19-64aulcdfm
@@ -1,0 +1,46 @@
+---
+arguments_string: fedora19-64a-ubuntu1610-64-fedora19-64aulcdfm
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    fedora19-64-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      hypervisor: vmpooler
+      platform: fedora-19-x86_64
+      template: fedora-19-x86_64
+      roles:
+      - agent
+    ubuntu1610-64-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      hypervisor: vmpooler
+      platform: ubuntu-16.10-amd64
+      template: ubuntu-1610-x86_64
+      roles:
+      - agent
+    fedora19-64-2:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      hypervisor: vmpooler
+      platform: fedora-19-x86_64
+      template: fedora-19-x86_64
+      roles:
+      - agent
+      - ca
+      - classifier
+      - dashboard
+      - database
+      - frictionless
+      - master
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception: 

--- a/test/fixtures/generated/multiplatform/fedora20-32u-ubuntu1610-32-fedora20-32m
+++ b/test/fixtures/generated/multiplatform/fedora20-32u-ubuntu1610-32-fedora20-32m
@@ -1,0 +1,42 @@
+---
+arguments_string: fedora20-32u-ubuntu1610-32-fedora20-32m
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    fedora20-32-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      hypervisor: vmpooler
+      platform: fedora-20-i386
+      template: fedora-20-i386
+      roles:
+      - agent
+      - ca
+    ubuntu1610-32-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      hypervisor: vmpooler
+      platform: ubuntu-16.10-i386
+      template: ubuntu-1610-i386
+      roles:
+      - agent
+    fedora20-32-2:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      hypervisor: vmpooler
+      platform: fedora-20-i386
+      template: fedora-20-i386
+      roles:
+      - agent
+      - master
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception: 

--- a/test/fixtures/generated/multiplatform/ubuntu1610-32l-fedora20-32-ubuntu1610-32f
+++ b/test/fixtures/generated/multiplatform/ubuntu1610-32l-fedora20-32-ubuntu1610-32f
@@ -1,0 +1,42 @@
+---
+arguments_string: ubuntu1610-32l-fedora20-32-ubuntu1610-32f
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    ubuntu1610-32-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      hypervisor: vmpooler
+      platform: ubuntu-16.10-i386
+      template: ubuntu-1610-i386
+      roles:
+      - agent
+      - classifier
+    fedora20-32-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      hypervisor: vmpooler
+      platform: fedora-20-i386
+      template: fedora-20-i386
+      roles:
+      - agent
+    ubuntu1610-32-2:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      hypervisor: vmpooler
+      platform: ubuntu-16.10-i386
+      template: ubuntu-1610-i386
+      roles:
+      - agent
+      - frictionless
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception: 

--- a/test/fixtures/generated/multiplatform/ubuntu1610-64c-fedora19-64-ubuntu1610-64d
+++ b/test/fixtures/generated/multiplatform/ubuntu1610-64c-fedora19-64-ubuntu1610-64d
@@ -1,0 +1,42 @@
+---
+arguments_string: ubuntu1610-64c-fedora19-64-ubuntu1610-64d
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    ubuntu1610-64-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      hypervisor: vmpooler
+      platform: ubuntu-16.10-amd64
+      template: ubuntu-1610-x86_64
+      roles:
+      - agent
+      - dashboard
+    fedora19-64-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      hypervisor: vmpooler
+      platform: fedora-19-x86_64
+      template: fedora-19-x86_64
+      roles:
+      - agent
+    ubuntu1610-64-2:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      hypervisor: vmpooler
+      platform: ubuntu-16.10-amd64
+      template: ubuntu-1610-x86_64
+      roles:
+      - agent
+      - database
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception: 

--- a/test/fixtures/generated/osinfo-version-0/ubuntu1610-32l
+++ b/test/fixtures/generated/osinfo-version-0/ubuntu1610-32l
@@ -1,0 +1,21 @@
+---
+arguments_string: "--osinfo-version 0 ubuntu1610-32l"
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    ubuntu1610-32-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      hypervisor: vmpooler
+      platform: ubuntu-16.10-i386
+      template: ubuntu-1610-i386
+      roles:
+      - agent
+      - classifier
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception: 

--- a/test/fixtures/generated/osinfo-version-0/ubuntu1610-64c
+++ b/test/fixtures/generated/osinfo-version-0/ubuntu1610-64c
@@ -1,0 +1,21 @@
+---
+arguments_string: "--osinfo-version 0 ubuntu1610-64c"
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    ubuntu1610-64-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      hypervisor: vmpooler
+      platform: ubuntu-16.10-amd64
+      template: ubuntu-1610-x86_64
+      roles:
+      - agent
+      - dashboard
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception: 

--- a/test/fixtures/generated/osinfo-version-1/ubuntu1610-32l
+++ b/test/fixtures/generated/osinfo-version-1/ubuntu1610-32l
@@ -1,0 +1,21 @@
+---
+arguments_string: "--osinfo-version 1 ubuntu1610-32l"
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    ubuntu1610-32-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      hypervisor: vmpooler
+      platform: ubuntu-16.10-i386
+      template: ubuntu-1610-i386
+      roles:
+      - agent
+      - classifier
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception: 

--- a/test/fixtures/generated/osinfo-version-1/ubuntu1610-64c
+++ b/test/fixtures/generated/osinfo-version-1/ubuntu1610-64c
@@ -1,0 +1,21 @@
+---
+arguments_string: "--osinfo-version 1 ubuntu1610-64c"
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    ubuntu1610-64-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      hypervisor: vmpooler
+      platform: ubuntu-16.10-amd64
+      template: ubuntu-1610-x86_64
+      roles:
+      - agent
+      - dashboard
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception: 


### PR DESCRIPTION
Added Ubuntu 16.10 platforms for i386 and x86_64. The test fixtures were created by running rake generate:fixtures.