### PR TITLE
(BKR-1032) Switched from using STDERR to using $stderr

### DIFF
--- a/bin/genconfig2
+++ b/bin/genconfig2
@@ -5,7 +5,7 @@ $LOAD_PATH.unshift(lib_dir)
 
 require 'beaker-hostgenerator'
 
-STDERR.puts("Warning: 'genconfig2' is deprecated and will be removed in beaker-hostgenerator 1.x\n\n")
+$stderr.puts("Warning: 'genconfig2' is deprecated and will be removed in beaker-hostgenerator 1.x\n\n")
 
 begin
   cli = BeakerHostGenerator::CLI.new

--- a/lib/beaker-hostgenerator/cli.rb
+++ b/lib/beaker-hostgenerator/cli.rb
@@ -179,7 +179,7 @@ rather than "el-4-x86_64". It is recommended that you update your project's test
 suites ASAP or be forced to do so when beaker-hostgenerator development moves on
 to the 1.x series. We don't intend to backport features or platforms to 0.x.
 eow
-        STDERR.puts(warning)
+        $stderr.puts(warning)
       end
     end
 

--- a/spec/beaker-hostgenerator/generator_spec.rb
+++ b/spec/beaker-hostgenerator/generator_spec.rb
@@ -53,7 +53,7 @@ module BeakerHostGenerator
       arguments = fixture_hash["arguments_string"]
       it "beaker-hostgenerator #{arguments}" do
         arguments = arguments.split
-        STDERR.reopen("stderr.txt", "w")
+        $stderr.reopen("stderr.txt", "w")
         fixture_hash['environment_variables'].each do |key, value|
           ENV[key] = value
         end

--- a/test/test_stdout.rb
+++ b/test/test_stdout.rb
@@ -18,4 +18,9 @@ class TestStdout < Minitest::Test
       assert_match(/.*#{spec_key}.*/, @stdout.string)
     end
   end
+
+  def test_ubuntu_host_generation_output
+    BeakerHostGenerator::CLI.new(['ubuntu1404-64default.mdcal-ubuntu1404-64af']).execute!
+    assert_match(/WARNING: Starting with beaker-hostgenerator 1\.x platform strings for "el" hosts/, @stderr.string)
+  end
 end

--- a/test/util/generator_helpers.rb
+++ b/test/util/generator_helpers.rb
@@ -7,7 +7,7 @@ module GeneratorTestHelpers
   include BeakerHostGenerator::Data
 
   def run_cli_with_options(options=[])
-    STDERR.reopen("stderr.txt", "w")
+    $stderr.reopen("stderr.txt", "w")
     cli = BeakerHostGenerator::CLI.new(options)
     yaml_string = cli.execute
 


### PR DESCRIPTION
Using $stderr permits redirecting of stderr to a log file or buffer
other than the default STDERR