### PR TITLE
(QENG-4019) Remove warning message about changing defaults

### DIFF
--- a/lib/beaker-hostgenerator/cli.rb
+++ b/lib/beaker-hostgenerator/cli.rb
@@ -157,7 +157,6 @@ Usage: beaker-hostgenerator [options] <layout>
         templates = BeakerHostGenerator::AbsSupport.extract_templates(config)
         templates.to_json
       else
-        print_warnings
         config = BeakerHostGenerator::Generator.new.generate(@layout, @options)
         config.to_yaml
       end
@@ -168,20 +167,6 @@ Usage: beaker-hostgenerator [options] <layout>
     end
 
     private
-
-    def print_warnings
-      if @options[:osinfo_version] === 0
-        warning = <<-eow
-WARNING: Starting with beaker-hostgenerator 1.x platform strings for "el" hosts
-will correspond to the actual linux distribution name. ie, the platform string
-corresponding to a host specified as "centos4_64a" will be "centos-4-x86_64"
-rather than "el-4-x86_64". It is recommended that you update your project's test
-suites ASAP or be forced to do so when beaker-hostgenerator development moves on
-to the 1.x series. We don't intend to backport features or platforms to 0.x.
-eow
-        STDERR.puts(warning)
-      end
-    end
 
     # Builds help text with a human-readable listing of all supported values
     # for the following: platforms, architectures, roles, and hypervisors.

--- a/spec/beaker-hostgenerator/generator_spec.rb
+++ b/spec/beaker-hostgenerator/generator_spec.rb
@@ -53,7 +53,6 @@ module BeakerHostGenerator
       arguments = fixture_hash["arguments_string"]
       it "beaker-hostgenerator #{arguments}" do
         arguments = arguments.split
-        STDERR.reopen("stderr.txt", "w")
         fixture_hash['environment_variables'].each do |key, value|
           ENV[key] = value
         end

--- a/test/util/generator_helpers.rb
+++ b/test/util/generator_helpers.rb
@@ -7,7 +7,6 @@ module GeneratorTestHelpers
   include BeakerHostGenerator::Data
 
   def run_cli_with_options(options=[])
-    STDERR.reopen("stderr.txt", "w")
     cli = BeakerHostGenerator::CLI.new(options)
     yaml_string = cli.execute
 


### PR DESCRIPTION
This warning message was added a while ago to inform users of an upcoming
breaking change. We're no longer certain that we'll be making the breaking
change though, so the warning is a bit misleading.

Furthermore, we're now trying to silence this message when beaker-hostgenerator
is used programatically within Beaker.

There will likely be more changes that are outlined in the linked ticket, such
as adding a new CLI switch to toggle between specific & generic platform names.