### PR TITLE
(MODULES-4667) Add Windows 2012R2 WMF5 VMPooler image

### DIFF
--- a/lib/beaker-hostgenerator/data.rb
+++ b/lib/beaker-hostgenerator/data.rb
@@ -896,6 +896,15 @@ module BeakerHostGenerator
             'template' => 'win-2012r2-x86_64'
           }
         },
+        'windows2012r2_wmf5-64' => {
+          :general => {
+            'platform' => 'windows-2012r2-64',
+            'ruby_arch' => 'x64'
+          },
+          :vmpooler => {
+            'template' => 'win-2012r2-wmf5-x86_64'
+          }
+        },
         'windows2012r2_ja-64' => {
           :general => {
             'platform' => 'windows-2012r2-64',

--- a/test/fixtures/generated/default/windows2012r2_wmf5-64l
+++ b/test/fixtures/generated/default/windows2012r2_wmf5-64l
@@ -1,0 +1,22 @@
+---
+arguments_string: windows2012r2_wmf5-64l
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    windows2012r2_wmf5-64-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      hypervisor: vmpooler
+      platform: windows-2012r2-64
+      ruby_arch: x64
+      template: win-2012r2-wmf5-x86_64
+      roles:
+      - agent
+      - classifier
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception: 

--- a/test/fixtures/generated/multiplatform/centos7-64c-windows2012r2_wmf5-64-centos7-64d
+++ b/test/fixtures/generated/multiplatform/centos7-64c-windows2012r2_wmf5-64-centos7-64d
@@ -1,0 +1,43 @@
+---
+arguments_string: centos7-64c-windows2012r2_wmf5-64-centos7-64d
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    centos7-64-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      hypervisor: vmpooler
+      platform: el-7-x86_64
+      template: centos-7-x86_64
+      roles:
+      - agent
+      - dashboard
+    windows2012r2_wmf5-64-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      hypervisor: vmpooler
+      platform: windows-2012r2-64
+      ruby_arch: x64
+      template: win-2012r2-wmf5-x86_64
+      roles:
+      - agent
+    centos7-64-2:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      hypervisor: vmpooler
+      platform: el-7-x86_64
+      template: centos-7-x86_64
+      roles:
+      - agent
+      - database
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception: 

--- a/test/fixtures/generated/multiplatform/windows2012r2_wmf5-64l-centos7-64-windows2012r2_wmf5-64f
+++ b/test/fixtures/generated/multiplatform/windows2012r2_wmf5-64l-centos7-64-windows2012r2_wmf5-64f
@@ -1,0 +1,44 @@
+---
+arguments_string: windows2012r2_wmf5-64l-centos7-64-windows2012r2_wmf5-64f
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    windows2012r2_wmf5-64-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      hypervisor: vmpooler
+      platform: windows-2012r2-64
+      ruby_arch: x64
+      template: win-2012r2-wmf5-x86_64
+      roles:
+      - agent
+      - classifier
+    centos7-64-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      hypervisor: vmpooler
+      platform: el-7-x86_64
+      template: centos-7-x86_64
+      roles:
+      - agent
+    windows2012r2_wmf5-64-2:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      hypervisor: vmpooler
+      platform: windows-2012r2-64
+      ruby_arch: x64
+      template: win-2012r2-wmf5-x86_64
+      roles:
+      - agent
+      - frictionless
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception: 

--- a/test/fixtures/generated/osinfo-version-0/windows2012r2_wmf5-64l
+++ b/test/fixtures/generated/osinfo-version-0/windows2012r2_wmf5-64l
@@ -1,0 +1,22 @@
+---
+arguments_string: "--osinfo-version 0 windows2012r2_wmf5-64l"
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    windows2012r2_wmf5-64-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      hypervisor: vmpooler
+      platform: windows-2012r2-64
+      ruby_arch: x64
+      template: win-2012r2-wmf5-x86_64
+      roles:
+      - agent
+      - classifier
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception: 

--- a/test/fixtures/generated/osinfo-version-1/windows2012r2_wmf5-64l
+++ b/test/fixtures/generated/osinfo-version-1/windows2012r2_wmf5-64l
@@ -1,0 +1,22 @@
+---
+arguments_string: "--osinfo-version 1 windows2012r2_wmf5-64l"
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    windows2012r2_wmf5-64-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      hypervisor: vmpooler
+      platform: windows-2012r2-64
+      ruby_arch: x64
+      template: win-2012r2-wmf5-x86_64
+      roles:
+      - agent
+      - classifier
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception: 


### PR DESCRIPTION
This commit adds the win-2012r2-wmf5-x86_64 vmpooler image, which is a variation
on the Windows Sever 2012R2 64bit image.