### PR TITLE
(maint) disks should be an array of integers

### DIFF
--- a/lib/beaker-hostgenerator/generator.rb
+++ b/lib/beaker-hostgenerator/generator.rb
@@ -63,6 +63,7 @@ module BeakerHostGenerator
         # Merge in any arbitrary key-value host settings. Treat the 'hostname'
         # setting specially, and don't merge it in as an arbitrary setting.
         arbitrary_settings = node_info['host_settings']
+        arbitrary_settings['disks'] = [arbitrary_settings['disks'].to_i] if arbitrary_settings['disks']
         host_name = arbitrary_settings.delete('hostname') if
           arbitrary_settings.has_key?('hostname')
         host_config.merge!(arbitrary_settings)


### PR DESCRIPTION
The ability to add disks to a vmpooler machine has been added to beaker and is set in the host file. Beaker is expecting an array of integers so if disks is present, this converts them to an array of integers before they're merged into the final config