### PR TITLE
(maint) The hypervisor defaults are not overwritable

### DIFF
--- a/lib/beaker-hostgenerator/generator.rb
+++ b/lib/beaker-hostgenerator/generator.rb
@@ -27,13 +27,6 @@ module BeakerHostGenerator
       ostype = nil
       bhg_version = options[:osinfo_version] || 0
 
-      # Merge in global configuration settings
-      if options[:global_config]
-        decoded = prepare(options[:global_config])
-        global_config = settings_string_to_map(decoded)
-        config['CONFIG'].deep_merge!(global_config)
-      end
-
       tokens.each do |token|
         if is_ostype_token?(token, bhg_version)
           if nodeid[ostype] == 1 and ostype != nil
@@ -76,6 +69,13 @@ module BeakerHostGenerator
 
         config['HOSTS'][host_name] = host_config
         nodeid[ostype] += 1
+      end
+
+      # Merge in global configuration settings after the hypervisor defaults
+      if options[:global_config]
+        decoded = prepare(options[:global_config])
+        global_config = settings_string_to_map(decoded)
+        config['CONFIG'].deep_merge!(global_config)
       end
 
       # Munge non-string scalar values into proper data types

--- a/lib/beaker-hostgenerator/hypervisor/vmpooler.rb
+++ b/lib/beaker-hostgenerator/hypervisor/vmpooler.rb
@@ -7,6 +7,7 @@ module BeakerHostGenerator
     class Vmpooler < BeakerHostGenerator::Hypervisor::Interface
       include BeakerHostGenerator::Data
 
+      # default global configuration keys
       def global_config()
         {
           'pooling_api' => 'http://vmpooler.delivery.puppetlabs.net/'

--- a/test/fixtures/per-host-settings/with-global-settings-overwrite.yaml
+++ b/test/fixtures/per-host-settings/with-global-settings-overwrite.yaml
@@ -1,0 +1,21 @@
+---
+arguments_string: "--global-config pooling_api=http://customvmpooler/ redhat7-64c"
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    redhat7-64-1:
+      pe_dir:
+      pe_ver:
+      pe_upgrade_dir:
+      pe_upgrade_ver:
+      hypervisor: vmpooler
+      platform: el-7-x86_64
+      template: redhat-7-x86_64
+      roles:
+        - agent
+        - dashboard
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://customvmpooler/
+expected_exception:


### PR DESCRIPTION
Before this change the code would pull and merge the hypervisor defaults on top of any
user provided --global-config block. This reverses the logic to use defaults only
if the key is not specified in the --global-config section. This specifically
enables overwritting the pooling_api for the vmpooler hypervisor, as it is the
only one with a default global_config() method implementation. Also added it's
respective test