### PR TITLE
(QENG-4945) Add support for arbitrary lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,49 @@ CONFIG:
   pooling_api: http://vmpooler.delivery.puppetlabs.net/
 ```
 
+### Two hosts with arbitrary host settings with arbitrary lists
+
+```
+$ beaker-hostgenerator centos6-64m{disks=\[16\]-redhat7-64a{disks=\[8\,16\]}
+```
+
+Will generate
+
+```yaml
+---
+HOSTS:
+  centos6-64-1:
+    pe_dir:
+    pe_ver:
+    pe_upgrade_dir:
+    pe_upgrade_ver:
+    platform: el-6-x86_64
+    hypervisor: vmpooler
+    disks:
+    - 16
+    roles:
+    - agent
+    - master
+  redhat7-64-1:
+    pe_dir:
+    pe_ver:
+    pe_upgrade_dir:
+    pe_upgrade_ver:
+    hypervisor: vmpooler
+    platform: el-7-x86_64
+    template: redhat-7-x86_64
+    disks:
+    - 8
+    - 16
+    roles:
+    - agent
+CONFIG:
+  nfs_server: none
+  consoleport: 443
+  pooling_api: http://vmpooler.delivery.puppetlabs.net/
+
+
+
 ### Arbitrary global configuration settings
 
 ```
@@ -227,12 +270,14 @@ It may be necessary to URL-encode the input in order for it to properly be used
 in certain contexts, such as Jenkins.
 
 In most cases it will only be necessary to escape the characters that support
-arbitrary settings, which means the following four characters:
+arbitrary settings, which means the following characters:
 
 - `{` is `%7B`
 - `,` is `%2C`
 - `}` is `%7D`
 - ` ` is `%20`
+- `[` is `%5B`
+- `]` is `%5D`
 
 For a full URL encoding reference see: http://www.w3schools.com/tags/ref_urlencode.asp
 

--- a/lib/beaker-hostgenerator/cli.rb
+++ b/lib/beaker-hostgenerator/cli.rb
@@ -28,7 +28,7 @@ module BeakerHostGenerator
 Usage: beaker-hostgenerator [options] <layout>
 
  where <layout> takes the following form:
-  <platform>-<arch>[[<arbitrary-roles>,[...]].]<roles>[{<arbitrary-settings>,[...]}][[<arbirary-list>;[...]]][-<arch>[[<arbitrary-roles>,[...]].]<roles>[{<arbitrary-settings>,[...]}]][-<layout>]
+  <platform>-<arch>[[<arbitrary-roles>,[...]].]<roles>[{<arbitrary-settings>,[...]}][-<arch>[[<arbitrary-roles>,[...]].]<roles>[{<arbitrary-settings>,[...]}]][-<layout>]
 
  examples:
   centos6-64mdca-32a
@@ -54,13 +54,13 @@ Usage: beaker-hostgenerator [options] <layout>
    1 CentOS 6 64 bit node with roles = master, hypervisor = none, node name = static1, and my-key = my-value
    1 CentOS 6 32 bit node with roles = agent and the default hypervisor
 
-example with arbitrary host lists:
-  centos6-64m[disks=8.16;my-list=my-value1]-32a
-   1 CentOS 6 64 bit node with roles = master and lists:
+ example of a list within arbitrary host settings:
+  centos6-64m{hostname=static1\\,disks=[8,16],my-list=[my-value1]}-32a
+   1 CentOS 6 64 bit node with roles = master, node name = static1 and lists:
       disks:
          - 8
          - 16
-       my-key:
+       my-list:
          - my-value1
    1 CentOS 6 32 bit node with roles = agent and the default hypervisor
 

--- a/lib/beaker-hostgenerator/cli.rb
+++ b/lib/beaker-hostgenerator/cli.rb
@@ -28,7 +28,7 @@ module BeakerHostGenerator
 Usage: beaker-hostgenerator [options] <layout>
 
  where <layout> takes the following form:
-  <platform>-<arch>[[<arbitrary-roles>,[...]].]<roles>[{<arbitrary-settings>,[...]}][-<arch>[[<arbitrary-roles>,[...]].]<roles>[{<arbitrary-settings>,[...]}]][-<layout>]
+  <platform>-<arch>[[<arbitrary-roles>,[...]].]<roles>[{<arbitrary-settings>,[...]}][[<arbirary-list>;[...]]][-<arch>[[<arbitrary-roles>,[...]].]<roles>[{<arbitrary-settings>,[...]}]][-<layout>]
 
  examples:
   centos6-64mdca-32a
@@ -52,6 +52,16 @@ Usage: beaker-hostgenerator [options] <layout>
  example with arbitrary host settings:
   centos6-64m{hypervisor=none\\,hostname=static1\\,my-key=my-value}-32a
    1 CentOS 6 64 bit node with roles = master, hypervisor = none, node name = static1, and my-key = my-value
+   1 CentOS 6 32 bit node with roles = agent and the default hypervisor
+
+example with arbitrary host lists:
+  centos6-64m[disks=8.16;my-list=my-value1]-32a
+   1 CentOS 6 64 bit node with roles = master and lists:
+      disks:
+         - 8
+         - 16
+       my-key:
+         - my-value1
    1 CentOS 6 32 bit node with roles = agent and the default hypervisor
 
  Generally, it is expected that beaker-hostgenerator output will be redirected to a file, for example:

--- a/lib/beaker-hostgenerator/generator.rb
+++ b/lib/beaker-hostgenerator/generator.rb
@@ -60,6 +60,10 @@ module BeakerHostGenerator
           arbitrary_settings.has_key?('hostname')
         host_config.merge!(arbitrary_settings)
 
+        # Merge in any arbitrary lists
+        arbitrary_settings = node_info['host_lists']
+        host_config.merge!(arbitrary_settings)
+
         if PE_USE_WIN32 && ostype =~ /windows/ && node_info['bits'] == "64"
           host_config['ruby_arch'] = 'x86'
           host_config['install_32'] = true

--- a/lib/beaker-hostgenerator/parser.rb
+++ b/lib/beaker-hostgenerator/parser.rb
@@ -189,6 +189,7 @@ module BeakerHostGenerator
       else
         node_info['host_settings'] = {}
       end
+
       return node_info
     end
 
@@ -208,12 +209,13 @@ module BeakerHostGenerator
     # @returns [Hash{String=>String|Array}] The host_settings string as a map.
     def settings_string_to_map(host_settings)
       # Strip it down to a list of pairs
-      # Spliting on all commas except inside `[]`
+      # Splitting on all commas except inside `[]`
       settings_pairs =
         host_settings.
         delete('{}').
         split(/,(?=[^\]]*(?:\[|$))/).
         map { |keyvalue| keyvalue.split('=') }
+
       # Validate they're actually pairs, and that all keys are non-empty
       settings_pairs.each do |pair|
         if pair.length != 2
@@ -225,6 +227,7 @@ module BeakerHostGenerator
                 "Malformed host settings: #{host_settings}"
         end
       end
+
       # Replace the remaining `,` to make array for arbitrary list if brackets exist
       settings_pairs.each do |pair|
         if pair[1].include?("[")

--- a/spec/beaker-hostgenerator/parser_spec.rb
+++ b/spec/beaker-hostgenerator/parser_spec.rb
@@ -113,12 +113,6 @@ module BeakerHostGenerator
       end
 
       context 'When using arbitrary host settings' do
-        it 'Properly tokenize settings and lists' do
-          expect( tokenize_layout("64{k1=v1,k2=v2,k4=[v3,v4,v5]}")).
-            to eq(["64{k1=v1,k2=v2,k4=[v3,v4,v5]}"])
-        end
-
-
         it 'Supports arbitrary whitespace in values' do
           expect( parse_node_info_token("64{k1=value 1,k2=v2,k3=  v3  ,k4=[v4, v5 ,v6]}") ).
             to eq({
@@ -146,7 +140,6 @@ module BeakerHostGenerator
 
           expect { parse_node_info_token("64{=}") }.
             to raise_error(BeakerHostGenerator::Exceptions::InvalidNodeSpecError)
-
         end
       end
     end

--- a/spec/beaker-hostgenerator/parser_spec.rb
+++ b/spec/beaker-hostgenerator/parser_spec.rb
@@ -6,8 +6,8 @@ module BeakerHostGenerator
 
     describe 'prepare' do
       it 'Supports URL-encoded input' do
-        expect( prepare('centos6-64m%7Bfoo=bar-baz,this=that%7D-32a%5Bfoo=bar,baz%3Bthis=that%5D') ).
-          to eq('centos6-64m{foo=bar-baz,this=that}-32a[foo=bar,baz;this=that]')
+        expect( prepare('centos6-64m%7Bfoo=bar-baz,this=that,foo=%5Bbar,baz%5D,this=%5Bthat%5D%7D-32a') ).
+          to eq('centos6-64m{foo=bar-baz,this=that,foo=[bar,baz],this=[that]}-32a')
       end
     end
 
@@ -24,7 +24,6 @@ module BeakerHostGenerator
                   "roles" => "",
                   "arbitrary_roles" => [],
                   "bits" => "64",
-                  "host_lists" => {},
                   "host_settings" => {}
                 })
       end
@@ -37,7 +36,6 @@ module BeakerHostGenerator
                     "roles" => "",
                     "arbitrary_roles" => [],
                     "bits" => "SPARC",
-                    "host_lists" => {},
                     "host_settings" => {}
                   })
 
@@ -46,7 +44,6 @@ module BeakerHostGenerator
                     "roles" => "",
                     "arbitrary_roles" => [],
                     "bits" => "POWER6",
-                    "host_lists" => {},
                     "host_settings" => {}
                   })
 
@@ -55,7 +52,6 @@ module BeakerHostGenerator
                     "roles" => "",
                     "arbitrary_roles" => [],
                     "bits" => "S390X",
-                    "host_lists" => {},
                     "host_settings" => {}
                   })
 
@@ -67,7 +63,6 @@ module BeakerHostGenerator
                     "roles" => "m",
                     "arbitrary_roles" => [],
                     "bits" => "S390X",
-                    "host_lists" => {},
                     "host_settings" => {}
                   })
 
@@ -76,7 +71,6 @@ module BeakerHostGenerator
                     "roles" => "m",
                     "arbitrary_roles" => ["custom"],
                     "bits" => "S390X",
-                    "host_lists" => {},
                     "host_settings" => {}
                   })
         end
@@ -96,7 +90,6 @@ module BeakerHostGenerator
                   "roles" => "mad",
                   "arbitrary_roles" => ["compile_master", "ca", "blah"],
                   "bits" => "64",
-                  "host_lists" => {},
                   "host_settings" => {}
                 })
       end
@@ -114,24 +107,29 @@ module BeakerHostGenerator
                     "roles" => "",
                     "arbitrary_roles" => ["compile_master", "ca", "blah"],
                     "bits" => "64",
-                    "host_lists" => {},
                     "host_settings" => {}
                   })
         end
       end
 
       context 'When using arbitrary host settings' do
+        it 'Properly tokenize settings and lists' do
+          expect( tokenize_layout("64{k1=v1,k2=v2,k4=[v3,v4,v5]}")).
+            to eq(["64{k1=v1,k2=v2,k4=[v3,v4,v5]}"])
+        end
+
+
         it 'Supports arbitrary whitespace in values' do
-          expect( parse_node_info_token("64{k1=value 1,k2=v2,k3=  v3  }") ).
+          expect( parse_node_info_token("64{k1=value 1,k2=v2,k3=  v3  ,k4=[v4, v5 ,v6]}") ).
             to eq({
                     "roles" => "",
                     "arbitrary_roles" => [],
                     "bits" => "64",
-                    "host_lists" => {},
                     "host_settings" => {
                       "k1" => "value 1",
                       "k2" => "v2",
-                      "k3" => "  v3  "
+                      "k3" => "  v3  ",
+                      "k4" => ["v4"," v5 ","v6"]
                     }
                   })
         end
@@ -148,40 +146,7 @@ module BeakerHostGenerator
 
           expect { parse_node_info_token("64{=}") }.
             to raise_error(BeakerHostGenerator::Exceptions::InvalidNodeSpecError)
-        end
 
-        context 'When using arbitrary host lists' do
-          it 'Supports arbitrary whitespace in lists' do
-            expect( parse_node_info_token("64[k1=value 1,value 2;k2=v2,v3,v4,v5;k3=  v6  ]") ).
-              to eq({
-                      "roles" => "",
-                      "arbitrary_roles" => [],
-                      "bits" => "64",
-                      "host_settings" => {},
-                      "host_lists" => {
-                        "k1" => ["value 1", "value 2"],
-                        "k2" => ["v2", "v3", "v4", "v5"],
-                        "k3" => ["  v6  "]
-                      }
-                    })
-          end
-
-          it 'Raises InvalidNodeSpecError for malformed key-list pairs' do
-            expect { parse_node_info_token("64[foo=bar=baz]") }.
-              to raise_error(BeakerHostGenerator::Exceptions::InvalidNodeSpecError)
-
-            expect { parse_node_info_token("64[foo=bar,barbar=baz]") }.
-              to raise_error(BeakerHostGenerator::Exceptions::InvalidNodeSpecError)
-
-            expect { parse_node_info_token("64[foo=]") }.
-              to raise_error(BeakerHostGenerator::Exceptions::InvalidNodeSpecError)
-
-            expect { parse_node_info_token("64[=bar,foo]") }.
-              to raise_error(BeakerHostGenerator::Exceptions::InvalidNodeSpecError)
-
-            expect { parse_node_info_token("64[=]") }.
-              to raise_error(BeakerHostGenerator::Exceptions::InvalidNodeSpecError)
-          end
         end
       end
     end


### PR DESCRIPTION
Before, we had no way to add lists to configurations. This adds a new bracket in order to parse out any lists the user may want to add in.

@nwolfe @eputnam 