### PR TITLE
(QENG-5041) Add vRO to support platforms

### DIFF
--- a/lib/beaker-hostgenerator/data.rb
+++ b/lib/beaker-hostgenerator/data.rb
@@ -779,6 +779,22 @@ module BeakerHostGenerator
             'template' => 'ubuntu-1610-x86_64'
           }
         },
+        'vro6-64' => {
+          :general => {
+            'platform' => 'sles-11-x86_64'
+          },
+          :vmpooler => {
+            'template' => 'vro-6-x86_64'
+          }
+        },
+        'vro7-64' => {
+          :general => {
+            'platform' => 'sles-11-x86_64'
+          },
+          :vmpooler => {
+            'template' => 'vro-7-x86_64'
+          }
+        },
         'windows2003-64' => {
           :general => {
             'platform' => 'windows-2003-64',

--- a/test/fixtures/generated/default/vro6-64f
+++ b/test/fixtures/generated/default/vro6-64f
@@ -1,0 +1,21 @@
+---
+arguments_string: vro6-64f
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    vro6-64-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      hypervisor: vmpooler
+      platform: sles-11-x86_64
+      template: vro-6-x86_64
+      roles:
+      - agent
+      - frictionless
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception: 

--- a/test/fixtures/generated/default/vro7-64m
+++ b/test/fixtures/generated/default/vro7-64m
@@ -1,0 +1,21 @@
+---
+arguments_string: vro7-64m
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    vro7-64-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      hypervisor: vmpooler
+      platform: sles-11-x86_64
+      template: vro-7-x86_64
+      roles:
+      - agent
+      - master
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception: 

--- a/test/fixtures/generated/multiplatform/vro6-64f-fedora20-32-vro6-64l
+++ b/test/fixtures/generated/multiplatform/vro6-64f-fedora20-32-vro6-64l
@@ -1,0 +1,42 @@
+---
+arguments_string: vro6-64f-fedora20-32-vro6-64l
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    vro6-64-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      hypervisor: vmpooler
+      platform: sles-11-x86_64
+      template: vro-6-x86_64
+      roles:
+      - agent
+      - frictionless
+    fedora20-32-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      hypervisor: vmpooler
+      platform: fedora-20-i386
+      template: fedora-20-i386
+      roles:
+      - agent
+    vro6-64-2:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      hypervisor: vmpooler
+      platform: sles-11-x86_64
+      template: vro-6-x86_64
+      roles:
+      - agent
+      - classifier
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception: 

--- a/test/fixtures/generated/multiplatform/vro7-64m-fedora19-64-vro7-64u
+++ b/test/fixtures/generated/multiplatform/vro7-64m-fedora19-64-vro7-64u
@@ -1,0 +1,42 @@
+---
+arguments_string: vro7-64m-fedora19-64-vro7-64u
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    vro7-64-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      hypervisor: vmpooler
+      platform: sles-11-x86_64
+      template: vro-7-x86_64
+      roles:
+      - agent
+      - master
+    fedora19-64-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      hypervisor: vmpooler
+      platform: fedora-19-x86_64
+      template: fedora-19-x86_64
+      roles:
+      - agent
+    vro7-64-2:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      hypervisor: vmpooler
+      platform: sles-11-x86_64
+      template: vro-7-x86_64
+      roles:
+      - agent
+      - ca
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception: 

--- a/test/fixtures/generated/osinfo-version-0/vro6-64f
+++ b/test/fixtures/generated/osinfo-version-0/vro6-64f
@@ -1,0 +1,21 @@
+---
+arguments_string: "--osinfo-version 0 vro6-64f"
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    vro6-64-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      hypervisor: vmpooler
+      platform: sles-11-x86_64
+      template: vro-6-x86_64
+      roles:
+      - agent
+      - frictionless
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception: 

--- a/test/fixtures/generated/osinfo-version-0/vro7-64m
+++ b/test/fixtures/generated/osinfo-version-0/vro7-64m
@@ -1,0 +1,21 @@
+---
+arguments_string: "--osinfo-version 0 vro7-64m"
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    vro7-64-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      hypervisor: vmpooler
+      platform: sles-11-x86_64
+      template: vro-7-x86_64
+      roles:
+      - agent
+      - master
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception: 

--- a/test/fixtures/generated/osinfo-version-1/vro6-64f
+++ b/test/fixtures/generated/osinfo-version-1/vro6-64f
@@ -1,0 +1,21 @@
+---
+arguments_string: "--osinfo-version 1 vro6-64f"
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    vro6-64-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      hypervisor: vmpooler
+      platform: sles-11-x86_64
+      template: vro-6-x86_64
+      roles:
+      - agent
+      - frictionless
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception: 

--- a/test/fixtures/generated/osinfo-version-1/vro7-64m
+++ b/test/fixtures/generated/osinfo-version-1/vro7-64m
@@ -1,0 +1,21 @@
+---
+arguments_string: "--osinfo-version 1 vro7-64m"
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    vro7-64-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      hypervisor: vmpooler
+      platform: sles-11-x86_64
+      template: vro-7-x86_64
+      roles:
+      - agent
+      - master
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception: 


### PR DESCRIPTION
This adds both `vro-6-x86_64` and `vro-7-x86_64`. The templates already exist within vmpooler.

@nwolfe 