### PR TITLE
(QENG-5128) Add arbitrary hash and array support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ host config files using a compact command line SUT specification.
         - [Single host with Arbitrary Roles](#single-host-with-arbitrary-roles)
         - [Two hosts with multiple hypervisors and arbitrary host settings](#two-hosts-with-multiple-hypervisors-and-arbitrary-host-settings)
         - [Two hosts with arbitrary host settings with arbitrary lists](#two-hosts-with-arbitrary-host-settings-with-arbitrary-lists)
+        - [Arbitrary nested hashes and arrays](#arbitrary-nested-hashes-and-arrays)
         - [Arbitrary global configuration settings](#arbitrary-global-configuration-settings)
         - [Custom hypervisor](#custom-hypervisor)
         - [URL-encoded input](#url-encoded-input)
@@ -200,6 +201,41 @@ CONFIG:
   pooling_api: http://vmpooler.delivery.puppetlabs.net/
 ```
 
+### Arbitrary nested hashes and arrays
+
+```
+$ beaker-hostgenerator --global-config {host_tags={lifetime=4h}\,list=[{listkey=listvalue}]\} redhat7-64m{hostlist=\[string\,{key=value}\,1234\]}
+```
+
+Will generate
+
+```yaml
+---
+HOSTS:
+  redhat7-64-1:
+    pe_dir:
+    pe_ver:
+    pe_upgrade_dir:
+    pe_upgrade_ver:
+    hypervisor: vmpooler
+    platform: el-7-x86_64
+    template: redhat-7-x86_64
+    hostlist:
+    - string
+    - key: value
+    - 1234
+    roles:
+    - agent
+    - master
+CONFIG:
+  nfs_server: none
+  consoleport: 443
+  pooling_api: http://vmpooler.delivery.puppetlabs.net/
+  host_tags:
+    lifetime: 4h
+  list:
+  - listkey: listvalue
+```
 
 ### Arbitrary global configuration settings
 

--- a/lib/beaker-hostgenerator/generator.rb
+++ b/lib/beaker-hostgenerator/generator.rb
@@ -74,6 +74,11 @@ module BeakerHostGenerator
       # Merge in global configuration settings after the hypervisor defaults
       if options[:global_config]
         decoded = prepare(options[:global_config])
+        # Support for strings without '{}' was introduced, so just double
+        # check here to ensure that we pass in values surrounded by '{}'.
+        if !decoded.start_with?('{')
+          decoded = "{#{decoded}}"
+        end
         global_config = settings_string_to_map(decoded)
         config['CONFIG'].deep_merge!(global_config)
       end

--- a/spec/beaker-hostgenerator/parser_spec.rb
+++ b/spec/beaker-hostgenerator/parser_spec.rb
@@ -113,6 +113,20 @@ module BeakerHostGenerator
       end
 
       context 'When using arbitrary host settings' do
+        it 'Supports arbitrary nested hashes and arrays' do
+          expect( parse_node_info_token("64{foo={bar=baz},foo2={bar2=baz2,bar22=baz22},foo3=bar3,foo4=[[bar4],baz4],list=[{map1=map11,map2=map22},{lastmap=lastmap2}]}") ).
+            to eq({
+                    "roles" => "",
+                    "arbitrary_roles" => [],
+                    "bits" => "64",
+                    "host_settings" =>
+                      {"foo"=>{"bar"=>"baz"},
+                      "foo2"=>{"bar2"=>"baz2", "bar22"=>"baz22"},
+                      "foo3"=>"bar3",
+                      "foo4"=>[["bar4"], "baz4"],
+                      "list"=>[{"map1"=>"map11", "map2"=>"map22"}, {"lastmap"=>"lastmap2"}]}})
+        end
+
         it 'Supports arbitrary whitespace in values' do
           expect( parse_node_info_token("64{k1=value 1,k2=v2,k3=  v3  ,k4=[v4, v5 ,v6]}") ).
             to eq({


### PR DESCRIPTION
Previous to this commit, the hostgenerator was restricted to shallow
hashes and arrays that could be conveyed in BHG syntax. This commit now
allows for arbitrary nesting of those data structures.