### PR TITLE
(IMAGES-497) Add support for Power8 Ubuntu 16.04 and RHEL 7

### DIFF
--- a/lib/beaker-hostgenerator/cli.rb
+++ b/lib/beaker-hostgenerator/cli.rb
@@ -192,7 +192,7 @@ Usage: beaker-hostgenerator [options] <layout>
       result << "   32    => 32-bit OS\n"
       result << "   64    => 64-bit OS\n"
       result << "   6432  => 64-bit OS with 32-bit Puppet (Windows Only)\n"
-      result << "   POWER => power or powerpc OS (AIX and Huawei only)\n"
+      result << "   POWER => power or powerpc OS (AIX, Huawei, Redhat and Ubuntu only)\n"
       result << "   SPARC => sparc OS (Solaris only)\n"
       result << "   S390X => s390x OS (RedHat and SLES only)\n"
       result << "\n\n"

--- a/lib/beaker-hostgenerator/data.rb
+++ b/lib/beaker-hostgenerator/data.rb
@@ -537,6 +537,14 @@ module BeakerHostGenerator
             'template' => 'redhat-7-x86_64'
           }
         },
+        'redhat7-POWER' => {
+          :general => {
+            'platform' => 'rhel-7.3-power8'
+          },
+          :abs => {
+            'template' => 'rhel-7.3-power8'
+          }
+        },
         'redhat7-S390X' => {
           :general => {
             'platform' => 'el-7-s390x'
@@ -790,6 +798,14 @@ module BeakerHostGenerator
           },
           :vmpooler => {
             'template' => 'ubuntu-1604-x86_64'
+          }
+        },
+        'ubuntu1604-POWER' => {
+          :general => {
+            'platform' => 'ubuntu-16.04-power8'
+          },
+          :abs => {
+            'template' => 'ubuntu-16.04-power8'
           }
         },
         'ubuntu1610-32' => {

--- a/spec/beaker-hostgenerator/abs_support_spec.rb
+++ b/spec/beaker-hostgenerator/abs_support_spec.rb
@@ -5,7 +5,7 @@ module BeakerHostGenerator
   describe AbsSupport do
     describe 'extract_templates' do
       it 'Returns a JSON map with template counts' do
-        input = ['aix53-POWER-aix61-POWER-aix71-POWER-aix72-POWER-huaweios6-POWER-solaris10-SPARC-solaris11-SPARC-centos7-64',
+        input = ['aix53-POWER-aix61-POWER-aix71-POWER-aix72-POWER-huaweios6-POWER-redhat7-POWER-solaris10-SPARC-solaris11-SPARC-centos7-64-ubuntu1604-POWER',
                  '--templates-only',
                  '--hypervisor', 'abs']
         expect( JSON.load(BeakerHostGenerator::CLI.new(input).execute) ).
@@ -14,9 +14,11 @@ module BeakerHostGenerator
                  'aix-7.1-power' => 1,
                  'aix-7.2-power' => 1,
                  'huaweios-6-powerpc' => 1,
+                 'rhel-7.3-power8' => 1,
                  'solaris-10-sparc' => 1,
                  'solaris-11-sparc' => 1,
-                 'centos-7-x86_64' => 1})
+                 'centos-7-x86_64' => 1,
+                 'ubuntu-16.04-power8' => 1})
       end
     end
   end

--- a/test/fixtures/generated/osinfo-version-0/redhat7-POWERl
+++ b/test/fixtures/generated/osinfo-version-0/redhat7-POWERl
@@ -1,0 +1,20 @@
+---
+arguments_string: "--osinfo-version 0 redhat7-POWERl"
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    redhat7-POWER-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      hypervisor: vmpooler
+      platform: rhel-7.3-power8
+      roles:
+      - agent
+      - classifier
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception: 

--- a/test/fixtures/generated/osinfo-version-0/ubuntu1604-POWERd
+++ b/test/fixtures/generated/osinfo-version-0/ubuntu1604-POWERd
@@ -1,0 +1,20 @@
+---
+arguments_string: "--osinfo-version 0 ubuntu1604-POWERd"
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    ubuntu1604-POWER-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      hypervisor: vmpooler
+      platform: ubuntu-16.04-power8
+      roles:
+      - agent
+      - database
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception: 

--- a/test/fixtures/generated/osinfo-version-1/redhat7-POWERl
+++ b/test/fixtures/generated/osinfo-version-1/redhat7-POWERl
@@ -1,0 +1,20 @@
+---
+arguments_string: "--osinfo-version 1 redhat7-POWERl"
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    redhat7-POWER-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      hypervisor: vmpooler
+      platform: rhel-7.3-power8
+      roles:
+      - agent
+      - classifier
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception: 

--- a/test/fixtures/generated/osinfo-version-1/ubuntu1604-POWERd
+++ b/test/fixtures/generated/osinfo-version-1/ubuntu1604-POWERd
@@ -1,0 +1,20 @@
+---
+arguments_string: "--osinfo-version 1 ubuntu1604-POWERd"
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    ubuntu1604-POWER-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      hypervisor: vmpooler
+      platform: ubuntu-16.04-power8
+      roles:
+      - agent
+      - database
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception: 


### PR DESCRIPTION
Note: I was a bit surprised to find that the test fixtures generated used 'vmpooler' for the hypervisor, but I checked and this is also the case for other ABS platforms, e.g, AIX 7.2. So I'm assuming this is not a problem.