### PR TITLE
(PE-21479) Rewrite pe_dir() to provide rc/pez builds from pe_version

### DIFF
--- a/lib/beaker-hostgenerator/data.rb
+++ b/lib/beaker-hostgenerator/data.rb
@@ -20,37 +20,25 @@ module BeakerHostGenerator
       ENV['pe_version']
     end
 
-    def pe_family
-      ENV['pe_family']
-    end
-
     def pe_upgrade_version
       ENV['pe_upgrade_version']
     end
 
-    def pe_upgrade_family
-      ENV['pe_upgrade_family']
-    end
+    def pe_dir(version)
+      return if version.nil?
 
-    def pe_dir(version, family)
-      # XXX family is no longer used, but it is possible that a job relied on the
-      # behavior that not setting family would return nil for pe_dir(), allowing beaker
-      # to pick up from ENV['BEAKER_PE_DIR'] or ENV['pe_dist_dir']
-      # https://github.com/puppetlabs/beaker/blob/3f52daf76b8b0a47a101a8ea76fbe4ace1e8efaf/lib/beaker/options/presets.rb#L25
-      if version && family
-        base_regex = '(\A\d+\.\d+)\.\d+'
-        source = case version
-        when /#{base_regex}\Z/
-          then "#{PE_TARBALL_SERVER}/archives/releases/#{version}/"
-        when /#{base_regex}-rc\d+\Z/
-          then "#{PE_TARBALL_SERVER}/archives/internal/%s/"
-        when /#{base_regex}-.*PEZ_.*/
-          then "#{PE_TARBALL_SERVER}/%s/feature/ci-ready"
-        when /#{base_regex}-.*/
-          then "#{PE_TARBALL_SERVER}/%s/ci-ready"
-        end
-        return sprintf(source, $1)
+      base_regex = '(\A\d+\.\d+)\.\d+'
+      source = case version
+      when /#{base_regex}\Z/
+        then "#{PE_TARBALL_SERVER}/archives/releases/#{version}/"
+      when /#{base_regex}-rc\d+\Z/
+        then "#{PE_TARBALL_SERVER}/archives/internal/%s/"
+      when /#{base_regex}-.*PEZ_.*/
+        then "#{PE_TARBALL_SERVER}/%s/feature/ci-ready"
+      when /#{base_regex}-.*/
+        then "#{PE_TARBALL_SERVER}/%s/ci-ready"
       end
+      return sprintf(source, $1)
     end
 
     PE_USE_WIN32 = ENV['pe_use_win32']
@@ -65,9 +53,9 @@ module BeakerHostGenerator
 
     def base_host_config(options)
       {
-        'pe_dir' => options[:pe_dir] || pe_dir(pe_version, pe_family),
+        'pe_dir' => options[:pe_dir] || pe_dir(pe_version),
         'pe_ver' => options[:pe_ver] || pe_version,
-        'pe_upgrade_dir' => options[:pe_upgrade_dir] || pe_dir(pe_upgrade_version, pe_upgrade_family),
+        'pe_upgrade_dir' => options[:pe_upgrade_dir] || pe_dir(pe_upgrade_version),
         'pe_upgrade_ver' => options[:pe_upgrade_ver] || pe_upgrade_version,
       }
     end

--- a/lib/beaker-hostgenerator/util.rb
+++ b/lib/beaker-hostgenerator/util.rb
@@ -7,8 +7,8 @@ module BeakerHostGenerator
   module Utils
     module_function
 
-    def pe_dir(version, family)
-      BeakerHostGenerator::Data.pe_dir(version, family)
+    def pe_dir(version, family = nil)
+      BeakerHostGenerator::Data.pe_dir(version)
     end
 
     def fixup_node(cfg)

--- a/spec/beaker-hostgenerator/generator_spec.rb
+++ b/spec/beaker-hostgenerator/generator_spec.rb
@@ -89,5 +89,47 @@ module BeakerHostGenerator
       end
     end
 
+    context "pe_dir" do
+      let(:dev_version) { '2017.3.0-rc4-11-g123abcd' }
+      let(:dev_version_no_rc) { '2017.3.0-1-g123abcd' }
+      let(:pez_version) { '2017.3.0-rc4-11-g123abcd-PEZ_foo' }
+      let(:release_version) { '2017.2.2' }
+      let(:rc_version) { '2017.3.0-rc4' }
+
+      it "returns ci-ready for a dev version" do
+        expect(BeakerHostGenerator::Data.pe_dir(dev_version, '2017.3')).to match(%r{2017\.3/ci-ready})
+        expect(BeakerHostGenerator::Data.pe_dir(dev_version_no_rc, '2017.3')).to match(%r{2017\.3/ci-ready})
+      end
+
+      it "returns ci-ready even if pe_family matches" do
+        expect(BeakerHostGenerator::Data.pe_dir(dev_version, dev_version)).to match(%r{2017\.3/ci-ready})
+        expect(BeakerHostGenerator::Data.pe_dir(dev_version_no_rc, dev_version_no_rc)).to match(%r{2017\.3/ci-ready})
+      end
+
+      it "returns archives/releases for a release version" do
+        expect(BeakerHostGenerator::Data.pe_dir(release_version, '2017.3')).to match(%r{archives/releases/2017\.2})
+      end
+
+      it "returns archives/internal for an rc version" do
+        expect(BeakerHostGenerator::Data.pe_dir(rc_version, '2017.3')).to match(%r{archives/internal/2017\.3})
+      end
+
+      it "returns archives/internal for an rc version even if pe_family matches" do
+        expect(BeakerHostGenerator::Data.pe_dir(rc_version, rc_version)).to match(%r{archives/internal/2017\.3})
+      end
+
+      it "returns feature/ci-ready for a PEZ version" do
+        expect(BeakerHostGenerator::Data.pe_dir(pez_version, '2017.3')).to match(%r{2017\.3/feature/ci-ready})
+      end
+
+      it "(backwards compatible) returns archives/release if pe_version matches pe_family" do
+        expect(BeakerHostGenerator::Data.pe_dir(release_version, release_version)).to match(%r{archives/releases/2017\.2\.2})
+      end
+
+      it "(backwords compatible) returns nil if eiher argument is nil" do
+        expect(BeakerHostGenerator::Data.pe_dir(nil, '2017.3')).to be_nil
+        expect(BeakerHostGenerator::Data.pe_dir(dev_version, nil)).to be_nil
+      end
+    end
   end
 end

--- a/spec/beaker-hostgenerator/generator_spec.rb
+++ b/spec/beaker-hostgenerator/generator_spec.rb
@@ -97,38 +97,24 @@ module BeakerHostGenerator
       let(:rc_version) { '2017.3.0-rc4' }
 
       it "returns ci-ready for a dev version" do
-        expect(BeakerHostGenerator::Data.pe_dir(dev_version, '2017.3')).to match(%r{2017\.3/ci-ready})
-        expect(BeakerHostGenerator::Data.pe_dir(dev_version_no_rc, '2017.3')).to match(%r{2017\.3/ci-ready})
-      end
-
-      it "returns ci-ready even if pe_family matches" do
-        expect(BeakerHostGenerator::Data.pe_dir(dev_version, dev_version)).to match(%r{2017\.3/ci-ready})
-        expect(BeakerHostGenerator::Data.pe_dir(dev_version_no_rc, dev_version_no_rc)).to match(%r{2017\.3/ci-ready})
+        expect(BeakerHostGenerator::Data.pe_dir(dev_version)).to match(%r{2017\.3/ci-ready})
+        expect(BeakerHostGenerator::Data.pe_dir(dev_version_no_rc)).to match(%r{2017\.3/ci-ready})
       end
 
       it "returns archives/releases for a release version" do
-        expect(BeakerHostGenerator::Data.pe_dir(release_version, '2017.3')).to match(%r{archives/releases/2017\.2})
+        expect(BeakerHostGenerator::Data.pe_dir(release_version)).to match(%r{archives/releases/2017\.2})
       end
 
       it "returns archives/internal for an rc version" do
-        expect(BeakerHostGenerator::Data.pe_dir(rc_version, '2017.3')).to match(%r{archives/internal/2017\.3})
-      end
-
-      it "returns archives/internal for an rc version even if pe_family matches" do
-        expect(BeakerHostGenerator::Data.pe_dir(rc_version, rc_version)).to match(%r{archives/internal/2017\.3})
+        expect(BeakerHostGenerator::Data.pe_dir(rc_version)).to match(%r{archives/internal/2017\.3})
       end
 
       it "returns feature/ci-ready for a PEZ version" do
-        expect(BeakerHostGenerator::Data.pe_dir(pez_version, '2017.3')).to match(%r{2017\.3/feature/ci-ready})
+        expect(BeakerHostGenerator::Data.pe_dir(pez_version)).to match(%r{2017\.3/feature/ci-ready})
       end
 
-      it "(backwards compatible) returns archives/release if pe_version matches pe_family" do
-        expect(BeakerHostGenerator::Data.pe_dir(release_version, release_version)).to match(%r{archives/releases/2017\.2\.2})
-      end
-
-      it "(backwords compatible) returns nil if eiher argument is nil" do
-        expect(BeakerHostGenerator::Data.pe_dir(nil, '2017.3')).to be_nil
-        expect(BeakerHostGenerator::Data.pe_dir(dev_version, nil)).to be_nil
+      it "returns nil if version is nil" do
+        expect(BeakerHostGenerator::Data.pe_dir(nil)).to be_nil
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,10 @@
+# The Rakefile includes this, but having them in spec_helper makes it possible
+# to run specific test cases via commandline when developing.
+local_libdir=File.join(__FILE__, '../../lib')
+local_testdir=File.join(__FILE__, '../../test')
+$LOAD_PATH.unshift(local_libdir) unless $LOAD_PATH.include?(local_libdir)
+$LOAD_PATH.unshift(local_testdir) unless $LOAD_PATH.include?(local_testdir)
+
 require 'simplecov'
 require 'beaker-hostgenerator'
 require 'helpers'


### PR DESCRIPTION
	(PE-21479) Rewrite pe_dir() to provide rc builds ￼…
...and to determine build source just from the pe_version format.
Previously, source was either archives/releases if version and family
were the exact same string, otherwise ci-ready.

Recently we have added archives/internal which houses rc tagged builds
long term (ci-ready has a two-week life span).  These internal archive
releases let us test rc builds for internal consumption, but introduced
a third source.

Fourth source, actually, I'd forgotten that we already had dev version
strings with PEZ in them that need to be sourced from
feature/ci-ready...

The patch bases everything off the version because the four cases are
mutually exclusive, and the previous determination of a release source
based on version == family doesn't make sense for anything but a release
version.  (If you supplied dev builds for both, for example, you
would get a host config trying to lookup a dev build in archive/releases
where it would not be found...)

This patch keeps the behavior of returning nil if either version or
family is nil so as to preserve a fallback behavior that would have
Beaker instead pick up pe_dir from environment variables: BEAKER_PE_DIR
or pe_dist_dir.

https://github.com/puppetlabs/beaker/blob/3.20.0/lib/beaker/options/presets.rb#L25

Ideally we would drop the family parameter altogether, but I think this
is a breaking change, and beaker-hostgenerator is public.