### PR TITLE
(BKR-1166) Rename rhel platform/template to redhat

### DIFF
--- a/lib/beaker-hostgenerator/data.rb
+++ b/lib/beaker-hostgenerator/data.rb
@@ -539,10 +539,10 @@ module BeakerHostGenerator
         },
         'redhat7-POWER' => {
           :general => {
-            'platform' => 'rhel-7.3-power8'
+            'platform' => 'redhat-7.3-power8'
           },
           :abs => {
-            'template' => 'rhel-7.3-power8'
+            'template' => 'redhat-7.3-power8'
           }
         },
         'redhat7-S390X' => {

--- a/spec/beaker-hostgenerator/abs_support_spec.rb
+++ b/spec/beaker-hostgenerator/abs_support_spec.rb
@@ -14,7 +14,7 @@ module BeakerHostGenerator
                  'aix-7.1-power' => 1,
                  'aix-7.2-power' => 1,
                  'huaweios-6-powerpc' => 1,
-                 'rhel-7.3-power8' => 1,
+                 'redhat-7.3-power8' => 1,
                  'solaris-10-sparc' => 1,
                  'solaris-11-sparc' => 1,
                  'centos-7-x86_64' => 1,

--- a/test/fixtures/generated/osinfo-version-0/redhat7-POWERl
+++ b/test/fixtures/generated/osinfo-version-0/redhat7-POWERl
@@ -9,7 +9,7 @@ expected_hash:
       pe_upgrade_dir: 
       pe_upgrade_ver: 
       hypervisor: vmpooler
-      platform: rhel-7.3-power8
+      platform: redhat-7.3-power8
       roles:
       - agent
       - classifier

--- a/test/fixtures/generated/osinfo-version-1/redhat7-POWERl
+++ b/test/fixtures/generated/osinfo-version-1/redhat7-POWERl
@@ -9,7 +9,7 @@ expected_hash:
       pe_upgrade_dir: 
       pe_upgrade_ver: 
       hypervisor: vmpooler
-      platform: rhel-7.3-power8
+      platform: redhat-7.3-power8
       roles:
       - agent
       - classifier


### PR DESCRIPTION
I've changed the RHEL 7.3 Power8 platform name in
hardware-infrastructure from 'rhel' to 'redhat' in order to follow the
existing naming conventions in beaker. 

This will help fix "unrecognized platform name" errors when trying to enable automated testing for this platform without having to make further changes in beaker.