### PR TITLE
Another round of Power8 changes

### DIFF
--- a/lib/beaker-hostgenerator/data.rb
+++ b/lib/beaker-hostgenerator/data.rb
@@ -539,7 +539,7 @@ module BeakerHostGenerator
         },
         'redhat7-POWER' => {
           :general => {
-            'platform' => 'redhat-7.3-power8'
+            'platform' => 'el-7-ppc64le'
           },
           :abs => {
             'template' => 'redhat-7.3-power8'

--- a/lib/beaker-hostgenerator/data.rb
+++ b/lib/beaker-hostgenerator/data.rb
@@ -802,7 +802,7 @@ module BeakerHostGenerator
         },
         'ubuntu1604-POWER' => {
           :general => {
-            'platform' => 'ubuntu-16.04-power8'
+            'platform' => 'ubuntu-16.04-ppc64el'
           },
           :abs => {
             'template' => 'ubuntu-16.04-power8'

--- a/test/fixtures/generated/osinfo-version-0/redhat7-POWERl
+++ b/test/fixtures/generated/osinfo-version-0/redhat7-POWERl
@@ -9,7 +9,7 @@ expected_hash:
       pe_upgrade_dir: 
       pe_upgrade_ver: 
       hypervisor: vmpooler
-      platform: redhat-7.3-power8
+      platform: el-7-ppc64le
       roles:
       - agent
       - classifier

--- a/test/fixtures/generated/osinfo-version-0/ubuntu1604-POWERd
+++ b/test/fixtures/generated/osinfo-version-0/ubuntu1604-POWERd
@@ -9,7 +9,7 @@ expected_hash:
       pe_upgrade_dir: 
       pe_upgrade_ver: 
       hypervisor: vmpooler
-      platform: ubuntu-16.04-power8
+      platform: ubuntu-16.04-ppc64el
       roles:
       - agent
       - database

--- a/test/fixtures/generated/osinfo-version-1/redhat7-POWERl
+++ b/test/fixtures/generated/osinfo-version-1/redhat7-POWERl
@@ -9,7 +9,7 @@ expected_hash:
       pe_upgrade_dir: 
       pe_upgrade_ver: 
       hypervisor: vmpooler
-      platform: redhat-7.3-power8
+      platform: el-7-ppc64le
       roles:
       - agent
       - classifier

--- a/test/fixtures/generated/osinfo-version-1/ubuntu1604-POWERd
+++ b/test/fixtures/generated/osinfo-version-1/ubuntu1604-POWERd
@@ -9,7 +9,7 @@ expected_hash:
       pe_upgrade_dir: 
       pe_upgrade_ver: 
       hypervisor: vmpooler
-      platform: ubuntu-16.04-power8
+      platform: ubuntu-16.04-ppc64el
       roles:
       - agent
       - database


### PR DESCRIPTION
My previous work on BHG to enable Power8 testing was based on some misconceptions, which I believe I've finally resolved. These platform definitions work with manual runs of beaker I've been able to test locally. Furthermore, there needs to be a discrepancy between the platform definition and the template definition for this to work with hwi that I've worked out with @McdonaldSeanp. 

Note: that's not a typo, Redhat calls their Power8 platform arch 'ppc64le' and Debian/Ubuntu call it 'ppc64el'. Go figure.