### PR TITLE
(PE-21479) Return nil if version is an empty string

### DIFF
--- a/lib/beaker-hostgenerator/data.rb
+++ b/lib/beaker-hostgenerator/data.rb
@@ -25,7 +25,7 @@ module BeakerHostGenerator
     end
 
     def pe_dir(version)
-      return if version.nil?
+      return if version.nil? || version.empty?
 
       base_regex = '(\A\d+\.\d+)\.\d+'
       source = case version
@@ -37,8 +37,10 @@ module BeakerHostGenerator
         then "#{PE_TARBALL_SERVER}/%s/feature/ci-ready"
       when /#{base_regex}-.*/
         then "#{PE_TARBALL_SERVER}/%s/ci-ready"
+      else
+        ''
       end
-      return sprintf(source, $1)
+      return sprintf(source, ($1 || ''))
     end
 
     PE_USE_WIN32 = ENV['pe_use_win32']

--- a/spec/beaker-hostgenerator/generator_spec.rb
+++ b/spec/beaker-hostgenerator/generator_spec.rb
@@ -116,6 +116,14 @@ module BeakerHostGenerator
       it "returns nil if version is nil" do
         expect(BeakerHostGenerator::Data.pe_dir(nil)).to be_nil
       end
+
+      it "returns nil if version is an empty string" do
+        expect(BeakerHostGenerator::Data.pe_dir('')).to be_nil
+      end
+
+      it "returns an empty string if version isn't parseable" do
+        expect(BeakerHostGenerator::Data.pe_dir('wtf')).to eq('')
+      end
     end
   end
 end


### PR DESCRIPTION
Missed this case, which errors out because we end giving a nil
substitution to sprintf.

Also tighten up the case of an unparseable version string to return ''.