### PR TITLE
(BKR-1174) Add support for SLES 12 on Power8

### DIFF
--- a/lib/beaker-hostgenerator/cli.rb
+++ b/lib/beaker-hostgenerator/cli.rb
@@ -192,7 +192,7 @@ Usage: beaker-hostgenerator [options] <layout>
       result << "   32    => 32-bit OS\n"
       result << "   64    => 64-bit OS\n"
       result << "   6432  => 64-bit OS with 32-bit Puppet (Windows Only)\n"
-      result << "   POWER => power or powerpc OS (AIX, Huawei, Redhat and Ubuntu only)\n"
+      result << "   POWER => power or powerpc OS (AIX, Huawei, Redhat, SLES and Ubuntu only)\n"
       result << "   SPARC => sparc OS (Solaris only)\n"
       result << "   S390X => s390x OS (RedHat and SLES only)\n"
       result << "\n\n"

--- a/lib/beaker-hostgenerator/data.rb
+++ b/lib/beaker-hostgenerator/data.rb
@@ -640,6 +640,14 @@ module BeakerHostGenerator
             'platform' => 'sles-12-s390x'
           }
         },
+        'sles12-POWER' => {
+          :general => {
+            'platform' => 'sles-12-ppc64le'
+          },
+          :abs => {
+            'template' => 'sles-12-power8'
+          }
+        },
         'solaris10-32' => {
           :general => {
             'platform' => 'solaris-10-i386'

--- a/spec/beaker-hostgenerator/abs_support_spec.rb
+++ b/spec/beaker-hostgenerator/abs_support_spec.rb
@@ -5,7 +5,7 @@ module BeakerHostGenerator
   describe AbsSupport do
     describe 'extract_templates' do
       it 'Returns a JSON map with template counts' do
-        input = ['aix53-POWER-aix61-POWER-aix71-POWER-aix72-POWER-huaweios6-POWER-redhat7-POWER-solaris10-SPARC-solaris11-SPARC-centos7-64-ubuntu1604-POWER',
+        input = ['aix53-POWER-aix61-POWER-aix71-POWER-aix72-POWER-huaweios6-POWER-redhat7-POWER-sles12-POWER-solaris10-SPARC-solaris11-SPARC-centos7-64-ubuntu1604-POWER',
                  '--templates-only',
                  '--hypervisor', 'abs']
         expect( JSON.load(BeakerHostGenerator::CLI.new(input).execute) ).
@@ -15,6 +15,7 @@ module BeakerHostGenerator
                  'aix-7.2-power' => 1,
                  'huaweios-6-powerpc' => 1,
                  'redhat-7.3-power8' => 1,
+                 'sles-12-power8' => 1,
                  'solaris-10-sparc' => 1,
                  'solaris-11-sparc' => 1,
                  'centos-7-x86_64' => 1,

--- a/test/fixtures/generated/osinfo-version-0/sles12-POWERa
+++ b/test/fixtures/generated/osinfo-version-0/sles12-POWERa
@@ -1,0 +1,19 @@
+---
+arguments_string: "--osinfo-version 0 sles12-POWERa"
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    sles12-POWER-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      hypervisor: vmpooler
+      platform: sles-12-ppc64le
+      roles:
+      - agent
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception: 

--- a/test/fixtures/generated/osinfo-version-1/sles12-POWERa
+++ b/test/fixtures/generated/osinfo-version-1/sles12-POWERa
@@ -1,0 +1,19 @@
+---
+arguments_string: "--osinfo-version 1 sles12-POWERa"
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    sles12-POWER-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      hypervisor: vmpooler
+      platform: sles-12-ppc64le
+      roles:
+      - agent
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception: 


### PR DESCRIPTION
Note: Power8 platforms make use of ABS templates.