### PR TITLE
(maint) Add cisconxhw data

### DIFF
--- a/lib/beaker-hostgenerator/data.rb
+++ b/lib/beaker-hostgenerator/data.rb
@@ -191,6 +191,19 @@ module BeakerHostGenerator
             'template' => 'cisco-nxos-9k-x86_64'
           }
         },
+        'cisconxhw-64' => {
+          :general => {
+            'platform'           => 'cisco_nexus-7-x86_64',
+            'packaging_platform' => 'cisco-wrlinux-5-x86_64',
+            'vrf' => 'management',
+            'ssh' => {
+              'user' => 'devops'
+            }
+          },
+          :abs => {
+            'template' => 'cisco-nxos_hw-9k-x86_64'
+          }
+        },
         'ciscoxr-64' => {
           :general => {
             'platform'           => 'cisco_ios_xr-6-x86_64',

--- a/test/fixtures/generated/default/cisconxhw-64f
+++ b/test/fixtures/generated/default/cisconxhw-64f
@@ -1,0 +1,24 @@
+---
+arguments_string: cisconxhw-64f
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    cisconxhw-64-1:
+      pe_dir:
+      pe_ver:
+      pe_upgrade_dir:
+      pe_upgrade_ver:
+      hypervisor: vmpooler
+      platform: cisco_nexus-7-x86_64
+      packaging_platform: cisco-wrlinux-5-x86_64
+      vrf: management
+      ssh:
+        user: devops
+      roles:
+      - agent
+      - frictionless
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception:

--- a/test/fixtures/generated/multiplatform/cisconxhw-64f-windows2012r2-64-cisconxhw-64l
+++ b/test/fixtures/generated/multiplatform/cisconxhw-64f-windows2012r2-64-cisconxhw-64l
@@ -1,0 +1,50 @@
+---
+arguments_string: cisconxhw-64f-windows2012r2-64-cisconxhw-64l
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    cisconxhw-64-1:
+      pe_dir:
+      pe_ver:
+      pe_upgrade_dir:
+      pe_upgrade_ver:
+      hypervisor: vmpooler
+      platform: cisco_nexus-7-x86_64
+      packaging_platform: cisco-wrlinux-5-x86_64
+      vrf: management
+      ssh:
+        user: devops
+      roles:
+      - agent
+      - frictionless
+    windows2012r2-64-1:
+      pe_dir:
+      pe_ver:
+      pe_upgrade_dir:
+      pe_upgrade_ver:
+      hypervisor: vmpooler
+      platform: windows-2012r2-64
+      packaging_platform: windows-2012-x64
+      ruby_arch: x64
+      template: win-2012r2-x86_64
+      roles:
+      - agent
+    cisconxhw-64-2:
+      pe_dir:
+      pe_ver:
+      pe_upgrade_dir:
+      pe_upgrade_ver:
+      hypervisor: vmpooler
+      platform: cisco_nexus-7-x86_64
+      packaging_platform: cisco-wrlinux-5-x86_64
+      vrf: management
+      ssh:
+        user: devops
+      roles:
+      - agent
+      - classifier
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/cisconxhw-64f
+++ b/test/fixtures/generated/osinfo-version-0/cisconxhw-64f
@@ -1,0 +1,24 @@
+---
+arguments_string: "--osinfo-version 0 cisconxhw-64f"
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    cisconxhw-64-1:
+      pe_dir:
+      pe_ver:
+      pe_upgrade_dir:
+      pe_upgrade_ver:
+      hypervisor: vmpooler
+      platform: cisco_nexus-7-x86_64
+      packaging_platform: cisco-wrlinux-5-x86_64
+      vrf: management
+      ssh:
+        user: devops
+      roles:
+      - agent
+      - frictionless
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/cisconxhw-64f
+++ b/test/fixtures/generated/osinfo-version-1/cisconxhw-64f
@@ -1,0 +1,24 @@
+---
+arguments_string: "--osinfo-version 1 cisconxhw-64f"
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    cisconxhw-64-1:
+      pe_dir:
+      pe_ver:
+      pe_upgrade_dir:
+      pe_upgrade_ver:
+      hypervisor: vmpooler
+      platform: cisco_nexus-7-x86_64
+      packaging_platform: cisco-wrlinux-5-x86_64
+      vrf: management
+      ssh:
+        user: devops
+      roles:
+      - agent
+      - frictionless
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception:


### PR DESCRIPTION
This commit adds data for cisconxhw to allow the use of hardware hosts (the
actual physical switches) when desired.