### PR TITLE
(IMAGES-614) Add Windows 2012r2/2016 Core defs

### DIFF
--- a/lib/beaker-hostgenerator/data.rb
+++ b/lib/beaker-hostgenerator/data.rb
@@ -1104,6 +1104,26 @@ module BeakerHostGenerator
             'template' => 'win-2012r2-ja-x86_64'
           }
         },
+        'windows2012r2_core-64' => {
+          :general => {
+            'platform'           => 'windows-2012r2-64',
+            'packaging_platform' => 'windows-2012-x64',
+            'ruby_arch' => 'x64'
+          },
+          :vmpooler => {
+            'template' => 'win-2012r2-core-x86_64'
+          }
+        },
+        'windows2012r2_core-6432' => {
+          :general => {
+            'platform'           => 'windows-2012r2-64',
+            'packaging_platform' => 'windows-2012-x64',
+            'ruby_arch' => 'x86'
+          },
+          :vmpooler => {
+            'template' => 'win-2012r2-core-x86_64'
+          }
+        },
         'windows2016-64' => {
           :general => {
             'platform'           => 'windows-2016-64',
@@ -1122,6 +1142,26 @@ module BeakerHostGenerator
           },
           :vmpooler => {
             'template' => 'win-2016-x86_64'
+          }
+        },
+        'windows2016_core-64' => {
+          :general => {
+            'platform'           => 'windows-2016-64',
+            'packaging_platform' => 'windows-2012-x64',
+            'ruby_arch' => 'x64'
+          },
+          :vmpooler => {
+            'template' => 'win-2016-core-x86_64'
+          }
+        },
+        'windows2016_core-6432' => {
+          :general => {
+            'platform'           => 'windows-2016-64',
+            'packaging_platform' => 'windows-2012-x64',
+            'ruby_arch' => 'x86'
+          },
+          :vmpooler => {
+            'template' => 'win-2016-core-x86_64'
           }
         },
         'windows7-64' => {


### PR DESCRIPTION
Add Beaker Host Generator definitions for:
1. Windows-2012r2-core-x86_64
2. Windows-2016-core-x86_64

Although these platforms are now on vmpooler, pipelines can't use them
without hostgenerator definitions.