### PR TITLE
(maint) Fix platform and packaging_platform for amazon6

### DIFF
--- a/lib/beaker-hostgenerator/data.rb
+++ b/lib/beaker-hostgenerator/data.rb
@@ -110,8 +110,8 @@ module BeakerHostGenerator
         },
         'amazon6-64' => {
             :general => {
-                'platform'           => 'amazon-6-x86_64',
-                'packaging_platform' => 'amazon-6-x86_64'
+                'platform'           => 'el-6-x86_64',
+                'packaging_platform' => 'el-6-x86_64'
             },
             :abs => {
                 'template' => 'amazon-6-x86_64'

--- a/test/fixtures/generated/default/amazon6-64d
+++ b/test/fixtures/generated/default/amazon6-64d
@@ -1,5 +1,5 @@
 ---
-arguments_string: amazon6-64a
+arguments_string: amazon6-64d
 environment_variables: {}
 expected_hash:
   HOSTS:
@@ -9,10 +9,11 @@ expected_hash:
       pe_upgrade_dir: 
       pe_upgrade_ver: 
       hypervisor: vmpooler
-      platform: amazon-6-x86_64
-      packaging_platform: amazon-6-x86_64
+      platform: el-6-x86_64
+      packaging_platform: el-6-x86_64
       roles:
       - agent
+      - database
   CONFIG:
     nfs_server: none
     consoleport: 443

--- a/test/fixtures/generated/multiplatform/amazon6-64d-windows81-64-amazon6-64c
+++ b/test/fixtures/generated/multiplatform/amazon6-64d-windows81-64-amazon6-64c
@@ -1,5 +1,5 @@
 ---
-arguments_string: amazon6-64a-windows10pro-64-amazon6-64aulcdfm
+arguments_string: amazon6-64d-windows81-64-amazon6-64c
 environment_variables: {}
 expected_hash:
   HOSTS:
@@ -9,20 +9,21 @@ expected_hash:
       pe_upgrade_dir: 
       pe_upgrade_ver: 
       hypervisor: vmpooler
-      platform: amazon-6-x86_64
-      packaging_platform: amazon-6-x86_64
+      platform: el-6-x86_64
+      packaging_platform: el-6-x86_64
       roles:
       - agent
-    windows10pro-64-1:
+      - database
+    windows81-64-1:
       pe_dir: 
       pe_ver: 
       pe_upgrade_dir: 
       pe_upgrade_ver: 
       hypervisor: vmpooler
-      platform: windows-10pro-64
+      platform: windows-8.1-64
       packaging_platform: windows-2012-x64
       ruby_arch: x64
-      template: win-10-pro-x86_64
+      template: win-81-x86_64
       roles:
       - agent
     amazon6-64-2:
@@ -31,16 +32,11 @@ expected_hash:
       pe_upgrade_dir: 
       pe_upgrade_ver: 
       hypervisor: vmpooler
-      platform: amazon-6-x86_64
-      packaging_platform: amazon-6-x86_64
+      platform: el-6-x86_64
+      packaging_platform: el-6-x86_64
       roles:
       - agent
-      - ca
-      - classifier
       - dashboard
-      - database
-      - frictionless
-      - master
   CONFIG:
     nfs_server: none
     consoleport: 443

--- a/test/fixtures/generated/osinfo-version-0/amazon6-64d
+++ b/test/fixtures/generated/osinfo-version-0/amazon6-64d
@@ -1,5 +1,5 @@
 ---
-arguments_string: "--osinfo-version 1 amazon6-64a"
+arguments_string: "--osinfo-version 0 amazon6-64d"
 environment_variables: {}
 expected_hash:
   HOSTS:
@@ -9,10 +9,11 @@ expected_hash:
       pe_upgrade_dir: 
       pe_upgrade_ver: 
       hypervisor: vmpooler
-      platform: amazon-6-x86_64
-      packaging_platform: amazon-6-x86_64
+      platform: el-6-x86_64
+      packaging_platform: el-6-x86_64
       roles:
       - agent
+      - database
   CONFIG:
     nfs_server: none
     consoleport: 443

--- a/test/fixtures/generated/osinfo-version-1/amazon6-64d
+++ b/test/fixtures/generated/osinfo-version-1/amazon6-64d
@@ -1,5 +1,5 @@
 ---
-arguments_string: "--osinfo-version 0 amazon6-64a"
+arguments_string: "--osinfo-version 1 amazon6-64d"
 environment_variables: {}
 expected_hash:
   HOSTS:
@@ -9,10 +9,11 @@ expected_hash:
       pe_upgrade_dir: 
       pe_upgrade_ver: 
       hypervisor: vmpooler
-      platform: amazon-6-x86_64
-      packaging_platform: amazon-6-x86_64
+      platform: el-6-x86_64
+      packaging_platform: el-6-x86_64
       roles:
       - agent
+      - database
   CONFIG:
     nfs_server: none
     consoleport: 443


### PR DESCRIPTION
Previously, this was trying to download and install PE based on the "amazon"
platform when it really needs to be using the el-6 package. Fixing to match
expected packages.