### PR TITLE
(BKR-1233) Update abs template string for AARCH64

### DIFF
--- a/lib/beaker-hostgenerator/data.rb
+++ b/lib/beaker-hostgenerator/data.rb
@@ -635,7 +635,7 @@ module BeakerHostGenerator
             'packaging_platform' => 'el-7-aarch64'
           },
           :abs => {
-            'template' => 'el-7-arm64'
+            'template' => 'centos-7-arm64'
           },
           :vmpooler => {
             'template' => 'redhat-7-x86_64'


### PR DESCRIPTION
centos-7-arm64 is the correct name of the target in NSpooler.

Since the abs templates are not used in the generated test fixtures, there are no updates to the fixtures with this change.