### PR TITLE
(IMAGES-335) Add Windows 2012r2 French

### DIFF
--- a/lib/beaker-hostgenerator/data.rb
+++ b/lib/beaker-hostgenerator/data.rb
@@ -1125,6 +1125,28 @@ module BeakerHostGenerator
             'template' => 'win-2012r2-ja-x86_64'
           }
         },
+        'windows2012r2_fr-64' => {
+          :general => {
+            'platform'           => 'windows-2012r2-64',
+            'packaging_platform' => 'windows-2012-x64',
+            'ruby_arch' => 'x64'
+          },
+          :vmpooler => {
+            'template' => 'win-2012r2-fr-x86_64',
+            'user'     => 'Administrateur'
+          }
+        },
+        'windows2012r2_fr-6432' => {
+          :general => {
+            'platform'           => 'windows-2012r2-64',
+            'packaging_platform' => 'windows-2012-x64',
+            'ruby_arch' => 'x86'
+          },
+          :vmpooler => {
+            'template' => 'win-2012r2-fr-x86_64',
+            'user'     => 'Administrateur'
+          }
+        },
         'windows2012r2_core-64' => {
           :general => {
             'platform'           => 'windows-2012r2-64',


### PR DESCRIPTION
Note - the Administrator Username has to be localised for beaker runs
for this platform, so the user attribute is also supplied for the
hosts.yaml file.