### PR TITLE
DO NOT MERGE (maint) Update the arbitrary choice of packaging platform

### DIFF
--- a/lib/beaker-hostgenerator/data.rb
+++ b/lib/beaker-hostgenerator/data.rb
@@ -968,7 +968,7 @@ module BeakerHostGenerator
         'windows2003-64' => {
           :general => {
             'platform'           => 'windows-2003-64',
-            'packaging_platform' => 'windows-2012-x64',
+            'packaging_platform' => 'windows-2012r2-x64',
             'ruby_arch' => 'x64'
           },
           :vmpooler => {
@@ -978,7 +978,7 @@ module BeakerHostGenerator
         'windows2003-6432' => {
           :general => {
             'platform'           => 'windows-2003-64',
-            'packaging_platform' => 'windows-2012-x64',
+            'packaging_platform' => 'windows-2012r2-x64',
             'ruby_arch' => 'x86'
           },
           :vmpooler => {
@@ -988,7 +988,7 @@ module BeakerHostGenerator
         'windows2003r2-32' => {
           :general => {
             'platform'           => 'windows-2003r2-32',
-            'packaging_platform' => 'windows-2012-x86',
+            'packaging_platform' => 'windows-2012r2-x86',
             'ruby_arch' => 'x86'
           },
           :vmpooler => {
@@ -998,7 +998,7 @@ module BeakerHostGenerator
         'windows2003r2-64' => {
           :general => {
             'platform'           => 'windows-2003r2-64',
-            'packaging_platform' => 'windows-2012-x64',
+            'packaging_platform' => 'windows-2012r2-x64',
             'ruby_arch' => 'x64'
           },
           :vmpooler => {
@@ -1008,7 +1008,7 @@ module BeakerHostGenerator
         'windows2003r2-6432' => {
           :general => {
             'platform'           => 'windows-2003r2-64',
-            'packaging_platform' => 'windows-2012-x64',
+            'packaging_platform' => 'windows-2012r2-x64',
             'ruby_arch' => 'x86'
           },
           :vmpooler => {
@@ -1018,7 +1018,7 @@ module BeakerHostGenerator
         'windows2008-64' => {
           :general => {
             'platform'           => 'windows-2008-64',
-            'packaging_platform' => 'windows-2012-x64',
+            'packaging_platform' => 'windows-2012r2-x64',
             'ruby_arch' => 'x64'
           },
           :vmpooler => {
@@ -1028,7 +1028,7 @@ module BeakerHostGenerator
         'windows2008-6432' => {
           :general => {
             'platform'           => 'windows-2008-64',
-            'packaging_platform' => 'windows-2012-x64',
+            'packaging_platform' => 'windows-2012r2-x64',
             'ruby_arch' => 'x86'
           },
           :vmpooler => {
@@ -1038,7 +1038,7 @@ module BeakerHostGenerator
         'windows2008r2-64' => {
           :general => {
             'platform'           => 'windows-2008r2-64',
-            'packaging_platform' => 'windows-2012-x64',
+            'packaging_platform' => 'windows-2012r2-x64',
             'ruby_arch' => 'x64'
           },
           :vmpooler => {
@@ -1048,7 +1048,7 @@ module BeakerHostGenerator
         'windows2008r2-6432' => {
           :general => {
             'platform'           => 'windows-2008r2-64',
-            'packaging_platform' => 'windows-2012-x64',
+            'packaging_platform' => 'windows-2012r2-x64',
             'ruby_arch' => 'x86'
           },
           :vmpooler => {
@@ -1058,7 +1058,7 @@ module BeakerHostGenerator
         'windows2012-64' => {
           :general => {
             'platform'           => 'windows-2012-64',
-            'packaging_platform' => 'windows-2012-x64',
+            'packaging_platform' => 'windows-2012r2-x64',
             'ruby_arch' => 'x64'
           },
           :vmpooler => {
@@ -1068,7 +1068,7 @@ module BeakerHostGenerator
         'windows2012-6432' => {
           :general => {
             'platform'           => 'windows-2012-64',
-            'packaging_platform' => 'windows-2012-x64',
+            'packaging_platform' => 'windows-2012r2-x64',
             'ruby_arch' => 'x86'
           },
           :vmpooler => {
@@ -1078,7 +1078,7 @@ module BeakerHostGenerator
         'windows2012r2-64' => {
           :general => {
             'platform'           => 'windows-2012r2-64',
-            'packaging_platform' => 'windows-2012-x64',
+            'packaging_platform' => 'windows-2012r2-x64',
             'ruby_arch' => 'x64'
           },
           :vmpooler => {
@@ -1088,7 +1088,7 @@ module BeakerHostGenerator
         'windows2012r2-6432' => {
           :general => {
             'platform'           => 'windows-2012r2-64',
-            'packaging_platform' => 'windows-2012-x64',
+            'packaging_platform' => 'windows-2012r2-x64',
             'ruby_arch' => 'x86'
           },
           :vmpooler => {
@@ -1098,7 +1098,7 @@ module BeakerHostGenerator
         'windows2012r2_wmf5-64' => {
           :general => {
             'platform'           => 'windows-2012r2-64',
-            'packaging_platform' => 'windows-2012-x64',
+            'packaging_platform' => 'windows-2012r2-x64',
             'ruby_arch' => 'x64'
           },
           :vmpooler => {
@@ -1108,7 +1108,7 @@ module BeakerHostGenerator
         'windows2012r2_ja-64' => {
           :general => {
             'platform'           => 'windows-2012r2-64',
-            'packaging_platform' => 'windows-2012-x64',
+            'packaging_platform' => 'windows-2012r2-x64',
             'ruby_arch' => 'x64'
           },
           :vmpooler => {
@@ -1118,7 +1118,7 @@ module BeakerHostGenerator
         'windows2012r2_ja-6432' => {
           :general => {
             'platform'           => 'windows-2012r2-64',
-            'packaging_platform' => 'windows-2012-x64',
+            'packaging_platform' => 'windows-2012r2-x64',
             'ruby_arch' => 'x86'
           },
           :vmpooler => {
@@ -1128,7 +1128,7 @@ module BeakerHostGenerator
         'windows2012r2_fr-64' => {
           :general => {
             'platform'           => 'windows-2012r2-64',
-            'packaging_platform' => 'windows-2012-x64',
+            'packaging_platform' => 'windows-2012r2-x64',
             'ruby_arch' => 'x64'
           },
           :vmpooler => {
@@ -1139,7 +1139,7 @@ module BeakerHostGenerator
         'windows2012r2_fr-6432' => {
           :general => {
             'platform'           => 'windows-2012r2-64',
-            'packaging_platform' => 'windows-2012-x64',
+            'packaging_platform' => 'windows-2012r2-x64',
             'ruby_arch' => 'x86'
           },
           :vmpooler => {
@@ -1150,7 +1150,7 @@ module BeakerHostGenerator
         'windows2012r2_core-64' => {
           :general => {
             'platform'           => 'windows-2012r2-64',
-            'packaging_platform' => 'windows-2012-x64',
+            'packaging_platform' => 'windows-2012r2-x64',
             'ruby_arch' => 'x64'
           },
           :vmpooler => {
@@ -1160,7 +1160,7 @@ module BeakerHostGenerator
         'windows2012r2_core-6432' => {
           :general => {
             'platform'           => 'windows-2012r2-64',
-            'packaging_platform' => 'windows-2012-x64',
+            'packaging_platform' => 'windows-2012r2-x64',
             'ruby_arch' => 'x86'
           },
           :vmpooler => {
@@ -1170,7 +1170,7 @@ module BeakerHostGenerator
         'windows2016-64' => {
           :general => {
             'platform'           => 'windows-2016-64',
-            'packaging_platform' => 'windows-2012-x64',
+            'packaging_platform' => 'windows-2012r2-x64',
             'ruby_arch' => 'x64'
           },
           :vmpooler => {
@@ -1180,7 +1180,7 @@ module BeakerHostGenerator
         'windows2016-6432' => {
           :general => {
             'platform'           => 'windows-2016-64',
-            'packaging_platform' => 'windows-2012-x64',
+            'packaging_platform' => 'windows-2012r2-x64',
             'ruby_arch' => 'x86'
           },
           :vmpooler => {
@@ -1190,7 +1190,7 @@ module BeakerHostGenerator
         'windows2016_core-64' => {
           :general => {
             'platform'           => 'windows-2016-64',
-            'packaging_platform' => 'windows-2012-x64',
+            'packaging_platform' => 'windows-2012r2-x64',
             'ruby_arch' => 'x64'
           },
           :vmpooler => {
@@ -1200,7 +1200,7 @@ module BeakerHostGenerator
         'windows2016_core-6432' => {
           :general => {
             'platform'           => 'windows-2016-64',
-            'packaging_platform' => 'windows-2012-x64',
+            'packaging_platform' => 'windows-2012r2-x64',
             'ruby_arch' => 'x86'
           },
           :vmpooler => {
@@ -1210,7 +1210,7 @@ module BeakerHostGenerator
         'windows7-64' => {
           :general => {
             'platform'           => 'windows-7-64',
-            'packaging_platform' => 'windows-2012-x64',
+            'packaging_platform' => 'windows-2012r2-x64',
             'ruby_arch' => 'x64'
           },
           :vmpooler => {
@@ -1220,7 +1220,7 @@ module BeakerHostGenerator
         'windows8-64' => {
           :general => {
             'platform'           => 'windows-8-64',
-            'packaging_platform' => 'windows-2012-x64',
+            'packaging_platform' => 'windows-2012r2-x64',
             'ruby_arch' => 'x64'
           },
           :vmpooler => {
@@ -1230,7 +1230,7 @@ module BeakerHostGenerator
         'windows81-64' => {
           :general => {
             'platform'           => 'windows-8.1-64',
-            'packaging_platform' => 'windows-2012-x64',
+            'packaging_platform' => 'windows-2012r2-x64',
             'ruby_arch' => 'x64'
           },
           :vmpooler => {
@@ -1240,7 +1240,7 @@ module BeakerHostGenerator
         'windowsvista-64' => {
           :general => {
             'platform'           => 'windows-vista-64',
-            'packaging_platform' => 'windows-2012-x64',
+            'packaging_platform' => 'windows-2012r2-x64',
             'ruby_arch' => 'x64'
           },
           :vmpooler => {
@@ -1250,7 +1250,7 @@ module BeakerHostGenerator
         'windows10ent-32' => {
           :general => {
             'platform'           => 'windows-10ent-32',
-            'packaging_platform' => 'windows-2012-x86',
+            'packaging_platform' => 'windows-2012r2-x86',
             'ruby_arch' => 'x86'
           },
           :vmpooler => {
@@ -1260,7 +1260,7 @@ module BeakerHostGenerator
         'windows10ent-64' => {
           :general => {
             'platform'           => 'windows-10ent-64',
-            'packaging_platform' => 'windows-2012-x64',
+            'packaging_platform' => 'windows-2012r2-x64',
             'ruby_arch' => 'x64'
           },
           :vmpooler => {
@@ -1270,7 +1270,7 @@ module BeakerHostGenerator
         'windows10pro-64' => {
           :general => {
             'platform'           => 'windows-10pro-64',
-            'packaging_platform' => 'windows-2012-x64',
+            'packaging_platform' => 'windows-2012r2-x64',
             'ruby_arch' => 'x64'
           },
           :vmpooler => {

--- a/test/fixtures/generated/default/windows10ent-32u
+++ b/test/fixtures/generated/default/windows10ent-32u
@@ -10,7 +10,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-10ent-32
-      packaging_platform: windows-2012-x86
+      packaging_platform: windows-2012r2-x86
       ruby_arch: x86
       template: win-10-ent-i386
       roles:

--- a/test/fixtures/generated/default/windows10ent-64l
+++ b/test/fixtures/generated/default/windows10ent-64l
@@ -10,7 +10,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-10ent-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x64
       template: win-10-ent-x86_64
       roles:

--- a/test/fixtures/generated/default/windows10pro-64c
+++ b/test/fixtures/generated/default/windows10pro-64c
@@ -10,7 +10,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-10pro-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x64
       template: win-10-pro-x86_64
       roles:

--- a/test/fixtures/generated/default/windows2003-6432d
+++ b/test/fixtures/generated/default/windows2003-6432d
@@ -10,7 +10,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2003-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x86
       template: win-2003-x86_64
       roles:

--- a/test/fixtures/generated/default/windows2003-64c
+++ b/test/fixtures/generated/default/windows2003-64c
@@ -10,7 +10,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2003-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x64
       template: win-2003-x86_64
       roles:

--- a/test/fixtures/generated/default/windows2003r2-32f
+++ b/test/fixtures/generated/default/windows2003r2-32f
@@ -10,7 +10,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2003r2-32
-      packaging_platform: windows-2012-x86
+      packaging_platform: windows-2012r2-x86
       ruby_arch: x86
       template: win-2003r2-i386
       roles:

--- a/test/fixtures/generated/default/windows2003r2-6432aulcdfm
+++ b/test/fixtures/generated/default/windows2003r2-6432aulcdfm
@@ -10,7 +10,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2003r2-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x86
       template: win-2003r2-x86_64
       roles:

--- a/test/fixtures/generated/default/windows2003r2-64m
+++ b/test/fixtures/generated/default/windows2003r2-64m
@@ -10,7 +10,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2003r2-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x64
       template: win-2003r2-x86_64
       roles:

--- a/test/fixtures/generated/default/windows2008-6432u
+++ b/test/fixtures/generated/default/windows2008-6432u
@@ -10,7 +10,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2008-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x86
       template: win-2008-x86_64
       roles:

--- a/test/fixtures/generated/default/windows2008-64a
+++ b/test/fixtures/generated/default/windows2008-64a
@@ -10,7 +10,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2008-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x64
       template: win-2008-x86_64
       roles:

--- a/test/fixtures/generated/default/windows2008r2-6432c
+++ b/test/fixtures/generated/default/windows2008r2-6432c
@@ -10,7 +10,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2008r2-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x86
       template: win-2008r2-x86_64
       roles:

--- a/test/fixtures/generated/default/windows2008r2-64l
+++ b/test/fixtures/generated/default/windows2008r2-64l
@@ -10,7 +10,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2008r2-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x64
       template: win-2008r2-x86_64
       roles:

--- a/test/fixtures/generated/default/windows2012-6432f
+++ b/test/fixtures/generated/default/windows2012-6432f
@@ -10,7 +10,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2012-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x86
       template: win-2012-x86_64
       roles:

--- a/test/fixtures/generated/default/windows2012-64d
+++ b/test/fixtures/generated/default/windows2012-64d
@@ -10,7 +10,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2012-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x64
       template: win-2012-x86_64
       roles:

--- a/test/fixtures/generated/default/windows2012r2-6432aulcdfm
+++ b/test/fixtures/generated/default/windows2012r2-6432aulcdfm
@@ -10,7 +10,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2012r2-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x86
       template: win-2012r2-x86_64
       roles:

--- a/test/fixtures/generated/default/windows2012r2-64m
+++ b/test/fixtures/generated/default/windows2012r2-64m
@@ -10,7 +10,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2012r2-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x64
       template: win-2012r2-x86_64
       roles:

--- a/test/fixtures/generated/default/windows2012r2_ja-6432l
+++ b/test/fixtures/generated/default/windows2012r2_ja-6432l
@@ -10,7 +10,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2012r2-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x86
       template: win-2012r2-ja-x86_64
       roles:

--- a/test/fixtures/generated/default/windows2012r2_ja-64u
+++ b/test/fixtures/generated/default/windows2012r2_ja-64u
@@ -10,7 +10,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2012r2-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x64
       template: win-2012r2-ja-x86_64
       roles:

--- a/test/fixtures/generated/default/windows2012r2_wmf5-64a
+++ b/test/fixtures/generated/default/windows2012r2_wmf5-64a
@@ -10,7 +10,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2012r2-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x64
       template: win-2012r2-wmf5-x86_64
       roles:

--- a/test/fixtures/generated/default/windows2016-6432d
+++ b/test/fixtures/generated/default/windows2016-6432d
@@ -10,7 +10,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2016-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x86
       template: win-2016-x86_64
       roles:

--- a/test/fixtures/generated/default/windows2016-64c
+++ b/test/fixtures/generated/default/windows2016-64c
@@ -10,7 +10,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2016-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x64
       template: win-2016-x86_64
       roles:

--- a/test/fixtures/generated/default/windows7-64f
+++ b/test/fixtures/generated/default/windows7-64f
@@ -10,7 +10,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-7-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x64
       template: win-7-x86_64
       roles:

--- a/test/fixtures/generated/default/windows8-64m
+++ b/test/fixtures/generated/default/windows8-64m
@@ -10,7 +10,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-8-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x64
       template: win-8-x86_64
       roles:

--- a/test/fixtures/generated/default/windows81-64aulcdfm
+++ b/test/fixtures/generated/default/windows81-64aulcdfm
@@ -10,7 +10,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-8.1-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x64
       template: win-81-x86_64
       roles:

--- a/test/fixtures/generated/default/windowsvista-64a
+++ b/test/fixtures/generated/default/windowsvista-64a
@@ -10,7 +10,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-vista-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x64
       template: win-vista-x86_64
       roles:

--- a/test/fixtures/generated/multiplatform/aix53-POWERa-windows10pro-64-aix53-POWERaulcdfm
+++ b/test/fixtures/generated/multiplatform/aix53-POWERa-windows10pro-64-aix53-POWERaulcdfm
@@ -20,7 +20,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-10pro-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x64
       template: win-10-pro-x86_64
       roles:

--- a/test/fixtures/generated/multiplatform/aix61-POWERu-windows10ent-64-aix61-POWERm
+++ b/test/fixtures/generated/multiplatform/aix61-POWERu-windows10ent-64-aix61-POWERm
@@ -21,7 +21,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-10ent-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x64
       template: win-10-ent-x86_64
       roles:

--- a/test/fixtures/generated/multiplatform/aix71-POWERl-windows10ent-32-aix71-POWERf
+++ b/test/fixtures/generated/multiplatform/aix71-POWERl-windows10ent-32-aix71-POWERf
@@ -21,7 +21,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-10ent-32
-      packaging_platform: windows-2012-x86
+      packaging_platform: windows-2012r2-x86
       ruby_arch: x86
       template: win-10-ent-i386
       roles:

--- a/test/fixtures/generated/multiplatform/aix72-POWERc-windowsvista-64-aix72-POWERd
+++ b/test/fixtures/generated/multiplatform/aix72-POWERc-windowsvista-64-aix72-POWERd
@@ -21,7 +21,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-vista-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x64
       template: win-vista-x86_64
       roles:

--- a/test/fixtures/generated/multiplatform/amazon6-64d-windows81-64-amazon6-64c
+++ b/test/fixtures/generated/multiplatform/amazon6-64d-windows81-64-amazon6-64c
@@ -21,7 +21,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-8.1-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x64
       template: win-81-x86_64
       roles:

--- a/test/fixtures/generated/multiplatform/arista4-32d-windows81-64-arista4-32c
+++ b/test/fixtures/generated/multiplatform/arista4-32d-windows81-64-arista4-32c
@@ -22,7 +22,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-8.1-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x64
       template: win-81-x86_64
       roles:

--- a/test/fixtures/generated/multiplatform/centos4-32f-windows8-64-centos4-32l
+++ b/test/fixtures/generated/multiplatform/centos4-32f-windows8-64-centos4-32l
@@ -21,7 +21,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-8-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x64
       template: win-8-x86_64
       roles:

--- a/test/fixtures/generated/multiplatform/centos4-64m-windows7-64-centos4-64u
+++ b/test/fixtures/generated/multiplatform/centos4-64m-windows7-64-centos4-64u
@@ -21,7 +21,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-7-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x64
       template: win-7-x86_64
       roles:

--- a/test/fixtures/generated/multiplatform/centos5-32aulcdfm-windows2016-6432-centos5-32a
+++ b/test/fixtures/generated/multiplatform/centos5-32aulcdfm-windows2016-6432-centos5-32a
@@ -27,7 +27,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2016-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x86
       template: win-2016-x86_64
       roles:

--- a/test/fixtures/generated/multiplatform/centos5-64a-windows2016-64-centos5-64aulcdfm
+++ b/test/fixtures/generated/multiplatform/centos5-64a-windows2016-64-centos5-64aulcdfm
@@ -21,7 +21,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2016-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x64
       template: win-2016-x86_64
       roles:

--- a/test/fixtures/generated/multiplatform/centos6-32u-windows2012r2_ja-6432-centos6-32m
+++ b/test/fixtures/generated/multiplatform/centos6-32u-windows2012r2_ja-6432-centos6-32m
@@ -22,7 +22,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2012r2-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x86
       template: win-2012r2-ja-x86_64
       roles:

--- a/test/fixtures/generated/multiplatform/centos6-64l-windows2012r2_ja-64-centos6-64f
+++ b/test/fixtures/generated/multiplatform/centos6-64l-windows2012r2_ja-64-centos6-64f
@@ -22,7 +22,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2012r2-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x64
       template: win-2012r2-ja-x86_64
       roles:

--- a/test/fixtures/generated/multiplatform/centos7-64c-windows2012r2_wmf5-64-centos7-64d
+++ b/test/fixtures/generated/multiplatform/centos7-64c-windows2012r2_wmf5-64-centos7-64d
@@ -22,7 +22,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2012r2-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x64
       template: win-2012r2-wmf5-x86_64
       roles:

--- a/test/fixtures/generated/multiplatform/cisconx-64d-windows2012r2-6432-cisconx-64c
+++ b/test/fixtures/generated/multiplatform/cisconx-64d-windows2012r2-6432-cisconx-64c
@@ -25,7 +25,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2012r2-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x86
       template: win-2012r2-x86_64
       roles:

--- a/test/fixtures/generated/multiplatform/cisconxhw-64f-windows2012r2-64-cisconxhw-64l
+++ b/test/fixtures/generated/multiplatform/cisconxhw-64f-windows2012r2-64-cisconxhw-64l
@@ -24,7 +24,7 @@ expected_hash:
       pe_upgrade_ver:
       hypervisor: vmpooler
       platform: windows-2012r2-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x64
       template: win-2012r2-x86_64
       roles:

--- a/test/fixtures/generated/multiplatform/ciscoxr-64f-windows2012r2-64-ciscoxr-64l
+++ b/test/fixtures/generated/multiplatform/ciscoxr-64f-windows2012r2-64-ciscoxr-64l
@@ -22,7 +22,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2012r2-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x64
       template: win-2012r2-x86_64
       roles:

--- a/test/fixtures/generated/multiplatform/cumulus25-64m-windows2012-6432-cumulus25-64u
+++ b/test/fixtures/generated/multiplatform/cumulus25-64m-windows2012-6432-cumulus25-64u
@@ -22,7 +22,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2012-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x86
       template: win-2012-x86_64
       roles:

--- a/test/fixtures/generated/multiplatform/debian6-32aulcdfm-windows2012-64-debian6-32a
+++ b/test/fixtures/generated/multiplatform/debian6-32aulcdfm-windows2012-64-debian6-32a
@@ -26,7 +26,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2012-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x64
       template: win-2012-x86_64
       roles:

--- a/test/fixtures/generated/multiplatform/debian6-64a-windows2008r2-6432-debian6-64aulcdfm
+++ b/test/fixtures/generated/multiplatform/debian6-64a-windows2008r2-6432-debian6-64aulcdfm
@@ -20,7 +20,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2008r2-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x86
       template: win-2008r2-x86_64
       roles:

--- a/test/fixtures/generated/multiplatform/debian7-32u-windows2008r2-64-debian7-32m
+++ b/test/fixtures/generated/multiplatform/debian7-32u-windows2008r2-64-debian7-32m
@@ -22,7 +22,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2008r2-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x64
       template: win-2008r2-x86_64
       roles:

--- a/test/fixtures/generated/multiplatform/debian7-64l-windows2008-6432-debian7-64f
+++ b/test/fixtures/generated/multiplatform/debian7-64l-windows2008-6432-debian7-64f
@@ -22,7 +22,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2008-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x86
       template: win-2008-x86_64
       roles:

--- a/test/fixtures/generated/multiplatform/debian8-32c-windows2008-64-debian8-32d
+++ b/test/fixtures/generated/multiplatform/debian8-32c-windows2008-64-debian8-32d
@@ -22,7 +22,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2008-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x64
       template: win-2008-x86_64
       roles:

--- a/test/fixtures/generated/multiplatform/debian8-64d-windows2003r2-6432-debian8-64c
+++ b/test/fixtures/generated/multiplatform/debian8-64d-windows2003r2-6432-debian8-64c
@@ -22,7 +22,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2003r2-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x86
       template: win-2003r2-x86_64
       roles:

--- a/test/fixtures/generated/multiplatform/debian9-32f-windows2003r2-64-debian9-32l
+++ b/test/fixtures/generated/multiplatform/debian9-32f-windows2003r2-64-debian9-32l
@@ -22,7 +22,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2003r2-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x64
       template: win-2003r2-x86_64
       roles:

--- a/test/fixtures/generated/multiplatform/debian9-64m-windows2003r2-32-debian9-64u
+++ b/test/fixtures/generated/multiplatform/debian9-64m-windows2003r2-32-debian9-64u
@@ -22,7 +22,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2003r2-32
-      packaging_platform: windows-2012-x86
+      packaging_platform: windows-2012r2-x86
       ruby_arch: x86
       template: win-2003r2-i386
       roles:

--- a/test/fixtures/generated/multiplatform/fedora14-32aulcdfm-windows2003-6432-fedora14-32a
+++ b/test/fixtures/generated/multiplatform/fedora14-32aulcdfm-windows2003-6432-fedora14-32a
@@ -26,7 +26,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2003-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x86
       template: win-2003-x86_64
       roles:

--- a/test/fixtures/generated/multiplatform/fedora19-32a-windows2003-64-fedora19-32aulcdfm
+++ b/test/fixtures/generated/multiplatform/fedora19-32a-windows2003-64-fedora19-32aulcdfm
@@ -20,7 +20,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2003-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x64
       template: win-2003-x86_64
       roles:

--- a/test/fixtures/generated/multiplatform/windows10ent-32u-aix71-POWER-windows10ent-32m
+++ b/test/fixtures/generated/multiplatform/windows10ent-32u-aix71-POWER-windows10ent-32m
@@ -10,7 +10,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-10ent-32
-      packaging_platform: windows-2012-x86
+      packaging_platform: windows-2012r2-x86
       ruby_arch: x86
       template: win-10-ent-i386
       roles:
@@ -33,7 +33,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-10ent-32
-      packaging_platform: windows-2012-x86
+      packaging_platform: windows-2012r2-x86
       ruby_arch: x86
       template: win-10-ent-i386
       roles:

--- a/test/fixtures/generated/multiplatform/windows10ent-64l-aix61-POWER-windows10ent-64f
+++ b/test/fixtures/generated/multiplatform/windows10ent-64l-aix61-POWER-windows10ent-64f
@@ -10,7 +10,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-10ent-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x64
       template: win-10-ent-x86_64
       roles:
@@ -33,7 +33,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-10ent-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x64
       template: win-10-ent-x86_64
       roles:

--- a/test/fixtures/generated/multiplatform/windows10pro-64c-aix53-POWER-windows10pro-64d
+++ b/test/fixtures/generated/multiplatform/windows10pro-64c-aix53-POWER-windows10pro-64d
@@ -10,7 +10,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-10pro-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x64
       template: win-10-pro-x86_64
       roles:
@@ -33,7 +33,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-10pro-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x64
       template: win-10-pro-x86_64
       roles:

--- a/test/fixtures/generated/multiplatform/windows2003-6432d-fedora14-32-windows2003-6432c
+++ b/test/fixtures/generated/multiplatform/windows2003-6432d-fedora14-32-windows2003-6432c
@@ -10,7 +10,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2003-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x86
       template: win-2003-x86_64
       roles:
@@ -33,7 +33,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2003-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x86
       template: win-2003-x86_64
       roles:

--- a/test/fixtures/generated/multiplatform/windows2003-64c-fedora19-32-windows2003-64d
+++ b/test/fixtures/generated/multiplatform/windows2003-64c-fedora19-32-windows2003-64d
@@ -10,7 +10,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2003-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x64
       template: win-2003-x86_64
       roles:
@@ -33,7 +33,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2003-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x64
       template: win-2003-x86_64
       roles:

--- a/test/fixtures/generated/multiplatform/windows2003r2-32f-debian9-64-windows2003r2-32l
+++ b/test/fixtures/generated/multiplatform/windows2003r2-32f-debian9-64-windows2003r2-32l
@@ -10,7 +10,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2003r2-32
-      packaging_platform: windows-2012-x86
+      packaging_platform: windows-2012r2-x86
       ruby_arch: x86
       template: win-2003r2-i386
       roles:
@@ -34,7 +34,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2003r2-32
-      packaging_platform: windows-2012-x86
+      packaging_platform: windows-2012r2-x86
       ruby_arch: x86
       template: win-2003r2-i386
       roles:

--- a/test/fixtures/generated/multiplatform/windows2003r2-6432aulcdfm-debian8-64-windows2003r2-6432a
+++ b/test/fixtures/generated/multiplatform/windows2003r2-6432aulcdfm-debian8-64-windows2003r2-6432a
@@ -10,7 +10,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2003r2-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x86
       template: win-2003r2-x86_64
       roles:
@@ -39,7 +39,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2003r2-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x86
       template: win-2003r2-x86_64
       roles:

--- a/test/fixtures/generated/multiplatform/windows2003r2-64m-debian9-32-windows2003r2-64u
+++ b/test/fixtures/generated/multiplatform/windows2003r2-64m-debian9-32-windows2003r2-64u
@@ -10,7 +10,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2003r2-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x64
       template: win-2003r2-x86_64
       roles:
@@ -34,7 +34,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2003r2-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x64
       template: win-2003r2-x86_64
       roles:

--- a/test/fixtures/generated/multiplatform/windows2008-6432u-debian7-64-windows2008-6432m
+++ b/test/fixtures/generated/multiplatform/windows2008-6432u-debian7-64-windows2008-6432m
@@ -10,7 +10,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2008-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x86
       template: win-2008-x86_64
       roles:
@@ -34,7 +34,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2008-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x86
       template: win-2008-x86_64
       roles:

--- a/test/fixtures/generated/multiplatform/windows2008-64a-debian8-32-windows2008-64aulcdfm
+++ b/test/fixtures/generated/multiplatform/windows2008-64a-debian8-32-windows2008-64aulcdfm
@@ -10,7 +10,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2008-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x64
       template: win-2008-x86_64
       roles:
@@ -33,7 +33,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2008-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x64
       template: win-2008-x86_64
       roles:

--- a/test/fixtures/generated/multiplatform/windows2008r2-6432c-debian6-64-windows2008r2-6432d
+++ b/test/fixtures/generated/multiplatform/windows2008r2-6432c-debian6-64-windows2008r2-6432d
@@ -10,7 +10,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2008r2-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x86
       template: win-2008r2-x86_64
       roles:
@@ -33,7 +33,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2008r2-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x86
       template: win-2008r2-x86_64
       roles:

--- a/test/fixtures/generated/multiplatform/windows2008r2-64l-debian7-32-windows2008r2-64f
+++ b/test/fixtures/generated/multiplatform/windows2008r2-64l-debian7-32-windows2008r2-64f
@@ -10,7 +10,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2008r2-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x64
       template: win-2008r2-x86_64
       roles:
@@ -34,7 +34,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2008r2-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x64
       template: win-2008r2-x86_64
       roles:

--- a/test/fixtures/generated/multiplatform/windows2012-6432f-cumulus25-64-windows2012-6432l
+++ b/test/fixtures/generated/multiplatform/windows2012-6432f-cumulus25-64-windows2012-6432l
@@ -10,7 +10,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2012-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x86
       template: win-2012-x86_64
       roles:
@@ -34,7 +34,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2012-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x86
       template: win-2012-x86_64
       roles:

--- a/test/fixtures/generated/multiplatform/windows2012-64d-debian6-32-windows2012-64c
+++ b/test/fixtures/generated/multiplatform/windows2012-64d-debian6-32-windows2012-64c
@@ -10,7 +10,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2012-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x64
       template: win-2012-x86_64
       roles:
@@ -33,7 +33,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2012-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x64
       template: win-2012-x86_64
       roles:

--- a/test/fixtures/generated/multiplatform/windows2012r2-6432aulcdfm-cisconx-64-windows2012r2-6432a
+++ b/test/fixtures/generated/multiplatform/windows2012r2-6432aulcdfm-cisconx-64-windows2012r2-6432a
@@ -10,7 +10,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2012r2-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x86
       template: win-2012r2-x86_64
       roles:
@@ -42,7 +42,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2012r2-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x86
       template: win-2012r2-x86_64
       roles:

--- a/test/fixtures/generated/multiplatform/windows2012r2-64m-ciscoxr-64-windows2012r2-64u
+++ b/test/fixtures/generated/multiplatform/windows2012r2-64m-ciscoxr-64-windows2012r2-64u
@@ -10,7 +10,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2012r2-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x64
       template: win-2012r2-x86_64
       roles:
@@ -34,7 +34,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2012r2-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x64
       template: win-2012r2-x86_64
       roles:

--- a/test/fixtures/generated/multiplatform/windows2012r2_ja-6432l-centos6-32-windows2012r2_ja-6432f
+++ b/test/fixtures/generated/multiplatform/windows2012r2_ja-6432l-centos6-32-windows2012r2_ja-6432f
@@ -10,7 +10,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2012r2-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x86
       template: win-2012r2-ja-x86_64
       roles:
@@ -34,7 +34,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2012r2-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x86
       template: win-2012r2-ja-x86_64
       roles:

--- a/test/fixtures/generated/multiplatform/windows2012r2_ja-64u-centos6-64-windows2012r2_ja-64m
+++ b/test/fixtures/generated/multiplatform/windows2012r2_ja-64u-centos6-64-windows2012r2_ja-64m
@@ -10,7 +10,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2012r2-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x64
       template: win-2012r2-ja-x86_64
       roles:
@@ -34,7 +34,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2012r2-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x64
       template: win-2012r2-ja-x86_64
       roles:

--- a/test/fixtures/generated/multiplatform/windows2012r2_wmf5-64a-centos7-64-windows2012r2_wmf5-64aulcdfm
+++ b/test/fixtures/generated/multiplatform/windows2012r2_wmf5-64a-centos7-64-windows2012r2_wmf5-64aulcdfm
@@ -10,7 +10,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2012r2-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x64
       template: win-2012r2-wmf5-x86_64
       roles:
@@ -33,7 +33,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2012r2-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x64
       template: win-2012r2-wmf5-x86_64
       roles:

--- a/test/fixtures/generated/multiplatform/windows2016-6432d-centos5-32-windows2016-6432c
+++ b/test/fixtures/generated/multiplatform/windows2016-6432d-centos5-32-windows2016-6432c
@@ -10,7 +10,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2016-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x86
       template: win-2016-x86_64
       roles:
@@ -34,7 +34,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2016-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x86
       template: win-2016-x86_64
       roles:

--- a/test/fixtures/generated/multiplatform/windows2016-64c-centos5-64-windows2016-64d
+++ b/test/fixtures/generated/multiplatform/windows2016-64c-centos5-64-windows2016-64d
@@ -10,7 +10,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2016-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x64
       template: win-2016-x86_64
       roles:
@@ -34,7 +34,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2016-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x64
       template: win-2016-x86_64
       roles:

--- a/test/fixtures/generated/multiplatform/windows7-64f-centos4-64-windows7-64l
+++ b/test/fixtures/generated/multiplatform/windows7-64f-centos4-64-windows7-64l
@@ -10,7 +10,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-7-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x64
       template: win-7-x86_64
       roles:
@@ -33,7 +33,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-7-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x64
       template: win-7-x86_64
       roles:

--- a/test/fixtures/generated/multiplatform/windows8-64m-centos4-32-windows8-64u
+++ b/test/fixtures/generated/multiplatform/windows8-64m-centos4-32-windows8-64u
@@ -10,7 +10,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-8-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x64
       template: win-8-x86_64
       roles:
@@ -33,7 +33,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-8-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x64
       template: win-8-x86_64
       roles:

--- a/test/fixtures/generated/multiplatform/windows81-64aulcdfm-arista4-32-windows81-64a
+++ b/test/fixtures/generated/multiplatform/windows81-64aulcdfm-arista4-32-windows81-64a
@@ -10,7 +10,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-8.1-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x64
       template: win-81-x86_64
       roles:
@@ -39,7 +39,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-8.1-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x64
       template: win-81-x86_64
       roles:

--- a/test/fixtures/generated/multiplatform/windowsvista-64a-aix72-POWER-windowsvista-64aulcdfm
+++ b/test/fixtures/generated/multiplatform/windowsvista-64a-aix72-POWER-windowsvista-64aulcdfm
@@ -10,7 +10,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-vista-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x64
       template: win-vista-x86_64
       roles:
@@ -32,7 +32,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-vista-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x64
       template: win-vista-x86_64
       roles:

--- a/test/fixtures/generated/osinfo-version-0/windows10ent-32u
+++ b/test/fixtures/generated/osinfo-version-0/windows10ent-32u
@@ -10,7 +10,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-10ent-32
-      packaging_platform: windows-2012-x86
+      packaging_platform: windows-2012r2-x86
       ruby_arch: x86
       template: win-10-ent-i386
       roles:

--- a/test/fixtures/generated/osinfo-version-0/windows10ent-64l
+++ b/test/fixtures/generated/osinfo-version-0/windows10ent-64l
@@ -10,7 +10,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-10ent-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x64
       template: win-10-ent-x86_64
       roles:

--- a/test/fixtures/generated/osinfo-version-0/windows10pro-64c
+++ b/test/fixtures/generated/osinfo-version-0/windows10pro-64c
@@ -10,7 +10,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-10pro-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x64
       template: win-10-pro-x86_64
       roles:

--- a/test/fixtures/generated/osinfo-version-0/windows2003-6432d
+++ b/test/fixtures/generated/osinfo-version-0/windows2003-6432d
@@ -10,7 +10,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2003-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x86
       template: win-2003-x86_64
       roles:

--- a/test/fixtures/generated/osinfo-version-0/windows2003-64c
+++ b/test/fixtures/generated/osinfo-version-0/windows2003-64c
@@ -10,7 +10,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2003-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x64
       template: win-2003-x86_64
       roles:

--- a/test/fixtures/generated/osinfo-version-0/windows2003r2-32f
+++ b/test/fixtures/generated/osinfo-version-0/windows2003r2-32f
@@ -10,7 +10,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2003r2-32
-      packaging_platform: windows-2012-x86
+      packaging_platform: windows-2012r2-x86
       ruby_arch: x86
       template: win-2003r2-i386
       roles:

--- a/test/fixtures/generated/osinfo-version-0/windows2003r2-6432aulcdfm
+++ b/test/fixtures/generated/osinfo-version-0/windows2003r2-6432aulcdfm
@@ -10,7 +10,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2003r2-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x86
       template: win-2003r2-x86_64
       roles:

--- a/test/fixtures/generated/osinfo-version-0/windows2003r2-64m
+++ b/test/fixtures/generated/osinfo-version-0/windows2003r2-64m
@@ -10,7 +10,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2003r2-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x64
       template: win-2003r2-x86_64
       roles:

--- a/test/fixtures/generated/osinfo-version-0/windows2008-6432u
+++ b/test/fixtures/generated/osinfo-version-0/windows2008-6432u
@@ -10,7 +10,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2008-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x86
       template: win-2008-x86_64
       roles:

--- a/test/fixtures/generated/osinfo-version-0/windows2008-64a
+++ b/test/fixtures/generated/osinfo-version-0/windows2008-64a
@@ -10,7 +10,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2008-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x64
       template: win-2008-x86_64
       roles:

--- a/test/fixtures/generated/osinfo-version-0/windows2008r2-6432c
+++ b/test/fixtures/generated/osinfo-version-0/windows2008r2-6432c
@@ -10,7 +10,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2008r2-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x86
       template: win-2008r2-x86_64
       roles:

--- a/test/fixtures/generated/osinfo-version-0/windows2008r2-64l
+++ b/test/fixtures/generated/osinfo-version-0/windows2008r2-64l
@@ -10,7 +10,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2008r2-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x64
       template: win-2008r2-x86_64
       roles:

--- a/test/fixtures/generated/osinfo-version-0/windows2012-6432f
+++ b/test/fixtures/generated/osinfo-version-0/windows2012-6432f
@@ -10,7 +10,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2012-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x86
       template: win-2012-x86_64
       roles:

--- a/test/fixtures/generated/osinfo-version-0/windows2012-64d
+++ b/test/fixtures/generated/osinfo-version-0/windows2012-64d
@@ -10,7 +10,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2012-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x64
       template: win-2012-x86_64
       roles:

--- a/test/fixtures/generated/osinfo-version-0/windows2012r2-6432aulcdfm
+++ b/test/fixtures/generated/osinfo-version-0/windows2012r2-6432aulcdfm
@@ -10,7 +10,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2012r2-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x86
       template: win-2012r2-x86_64
       roles:

--- a/test/fixtures/generated/osinfo-version-0/windows2012r2-64m
+++ b/test/fixtures/generated/osinfo-version-0/windows2012r2-64m
@@ -10,7 +10,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2012r2-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x64
       template: win-2012r2-x86_64
       roles:

--- a/test/fixtures/generated/osinfo-version-0/windows2012r2_ja-6432l
+++ b/test/fixtures/generated/osinfo-version-0/windows2012r2_ja-6432l
@@ -10,7 +10,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2012r2-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x86
       template: win-2012r2-ja-x86_64
       roles:

--- a/test/fixtures/generated/osinfo-version-0/windows2012r2_ja-64u
+++ b/test/fixtures/generated/osinfo-version-0/windows2012r2_ja-64u
@@ -10,7 +10,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2012r2-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x64
       template: win-2012r2-ja-x86_64
       roles:

--- a/test/fixtures/generated/osinfo-version-0/windows2012r2_wmf5-64a
+++ b/test/fixtures/generated/osinfo-version-0/windows2012r2_wmf5-64a
@@ -10,7 +10,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2012r2-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x64
       template: win-2012r2-wmf5-x86_64
       roles:

--- a/test/fixtures/generated/osinfo-version-0/windows2016-6432d
+++ b/test/fixtures/generated/osinfo-version-0/windows2016-6432d
@@ -10,7 +10,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2016-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x86
       template: win-2016-x86_64
       roles:

--- a/test/fixtures/generated/osinfo-version-0/windows2016-64c
+++ b/test/fixtures/generated/osinfo-version-0/windows2016-64c
@@ -10,7 +10,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2016-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x64
       template: win-2016-x86_64
       roles:

--- a/test/fixtures/generated/osinfo-version-0/windows7-64f
+++ b/test/fixtures/generated/osinfo-version-0/windows7-64f
@@ -10,7 +10,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-7-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x64
       template: win-7-x86_64
       roles:

--- a/test/fixtures/generated/osinfo-version-0/windows8-64m
+++ b/test/fixtures/generated/osinfo-version-0/windows8-64m
@@ -10,7 +10,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-8-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x64
       template: win-8-x86_64
       roles:

--- a/test/fixtures/generated/osinfo-version-0/windows81-64aulcdfm
+++ b/test/fixtures/generated/osinfo-version-0/windows81-64aulcdfm
@@ -10,7 +10,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-8.1-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x64
       template: win-81-x86_64
       roles:

--- a/test/fixtures/generated/osinfo-version-0/windowsvista-64a
+++ b/test/fixtures/generated/osinfo-version-0/windowsvista-64a
@@ -10,7 +10,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-vista-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x64
       template: win-vista-x86_64
       roles:

--- a/test/fixtures/generated/osinfo-version-1/windows10ent-32u
+++ b/test/fixtures/generated/osinfo-version-1/windows10ent-32u
@@ -10,7 +10,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-10ent-32
-      packaging_platform: windows-2012-x86
+      packaging_platform: windows-2012r2-x86
       ruby_arch: x86
       template: win-10-ent-i386
       roles:

--- a/test/fixtures/generated/osinfo-version-1/windows10ent-64l
+++ b/test/fixtures/generated/osinfo-version-1/windows10ent-64l
@@ -10,7 +10,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-10ent-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x64
       template: win-10-ent-x86_64
       roles:

--- a/test/fixtures/generated/osinfo-version-1/windows10pro-64c
+++ b/test/fixtures/generated/osinfo-version-1/windows10pro-64c
@@ -10,7 +10,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-10pro-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x64
       template: win-10-pro-x86_64
       roles:

--- a/test/fixtures/generated/osinfo-version-1/windows2003-6432d
+++ b/test/fixtures/generated/osinfo-version-1/windows2003-6432d
@@ -10,7 +10,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2003-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x86
       template: win-2003-x86_64
       roles:

--- a/test/fixtures/generated/osinfo-version-1/windows2003-64c
+++ b/test/fixtures/generated/osinfo-version-1/windows2003-64c
@@ -10,7 +10,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2003-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x64
       template: win-2003-x86_64
       roles:

--- a/test/fixtures/generated/osinfo-version-1/windows2003r2-32f
+++ b/test/fixtures/generated/osinfo-version-1/windows2003r2-32f
@@ -10,7 +10,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2003r2-32
-      packaging_platform: windows-2012-x86
+      packaging_platform: windows-2012r2-x86
       ruby_arch: x86
       template: win-2003r2-i386
       roles:

--- a/test/fixtures/generated/osinfo-version-1/windows2003r2-6432aulcdfm
+++ b/test/fixtures/generated/osinfo-version-1/windows2003r2-6432aulcdfm
@@ -10,7 +10,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2003r2-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x86
       template: win-2003r2-x86_64
       roles:

--- a/test/fixtures/generated/osinfo-version-1/windows2003r2-64m
+++ b/test/fixtures/generated/osinfo-version-1/windows2003r2-64m
@@ -10,7 +10,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2003r2-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x64
       template: win-2003r2-x86_64
       roles:

--- a/test/fixtures/generated/osinfo-version-1/windows2008-6432u
+++ b/test/fixtures/generated/osinfo-version-1/windows2008-6432u
@@ -10,7 +10,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2008-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x86
       template: win-2008-x86_64
       roles:

--- a/test/fixtures/generated/osinfo-version-1/windows2008-64a
+++ b/test/fixtures/generated/osinfo-version-1/windows2008-64a
@@ -10,7 +10,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2008-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x64
       template: win-2008-x86_64
       roles:

--- a/test/fixtures/generated/osinfo-version-1/windows2008r2-6432c
+++ b/test/fixtures/generated/osinfo-version-1/windows2008r2-6432c
@@ -10,7 +10,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2008r2-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x86
       template: win-2008r2-x86_64
       roles:

--- a/test/fixtures/generated/osinfo-version-1/windows2008r2-64l
+++ b/test/fixtures/generated/osinfo-version-1/windows2008r2-64l
@@ -10,7 +10,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2008r2-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x64
       template: win-2008r2-x86_64
       roles:

--- a/test/fixtures/generated/osinfo-version-1/windows2012-6432f
+++ b/test/fixtures/generated/osinfo-version-1/windows2012-6432f
@@ -10,7 +10,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2012-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x86
       template: win-2012-x86_64
       roles:

--- a/test/fixtures/generated/osinfo-version-1/windows2012-64d
+++ b/test/fixtures/generated/osinfo-version-1/windows2012-64d
@@ -10,7 +10,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2012-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x64
       template: win-2012-x86_64
       roles:

--- a/test/fixtures/generated/osinfo-version-1/windows2012r2-6432aulcdfm
+++ b/test/fixtures/generated/osinfo-version-1/windows2012r2-6432aulcdfm
@@ -10,7 +10,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2012r2-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x86
       template: win-2012r2-x86_64
       roles:

--- a/test/fixtures/generated/osinfo-version-1/windows2012r2-64m
+++ b/test/fixtures/generated/osinfo-version-1/windows2012r2-64m
@@ -10,7 +10,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2012r2-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x64
       template: win-2012r2-x86_64
       roles:

--- a/test/fixtures/generated/osinfo-version-1/windows2012r2_ja-6432l
+++ b/test/fixtures/generated/osinfo-version-1/windows2012r2_ja-6432l
@@ -10,7 +10,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2012r2-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x86
       template: win-2012r2-ja-x86_64
       roles:

--- a/test/fixtures/generated/osinfo-version-1/windows2012r2_ja-64u
+++ b/test/fixtures/generated/osinfo-version-1/windows2012r2_ja-64u
@@ -10,7 +10,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2012r2-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x64
       template: win-2012r2-ja-x86_64
       roles:

--- a/test/fixtures/generated/osinfo-version-1/windows2012r2_wmf5-64a
+++ b/test/fixtures/generated/osinfo-version-1/windows2012r2_wmf5-64a
@@ -10,7 +10,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2012r2-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x64
       template: win-2012r2-wmf5-x86_64
       roles:

--- a/test/fixtures/generated/osinfo-version-1/windows2016-6432d
+++ b/test/fixtures/generated/osinfo-version-1/windows2016-6432d
@@ -10,7 +10,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2016-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x86
       template: win-2016-x86_64
       roles:

--- a/test/fixtures/generated/osinfo-version-1/windows2016-64c
+++ b/test/fixtures/generated/osinfo-version-1/windows2016-64c
@@ -10,7 +10,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-2016-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x64
       template: win-2016-x86_64
       roles:

--- a/test/fixtures/generated/osinfo-version-1/windows7-64f
+++ b/test/fixtures/generated/osinfo-version-1/windows7-64f
@@ -10,7 +10,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-7-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x64
       template: win-7-x86_64
       roles:

--- a/test/fixtures/generated/osinfo-version-1/windows8-64m
+++ b/test/fixtures/generated/osinfo-version-1/windows8-64m
@@ -10,7 +10,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-8-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x64
       template: win-8-x86_64
       roles:

--- a/test/fixtures/generated/osinfo-version-1/windows81-64aulcdfm
+++ b/test/fixtures/generated/osinfo-version-1/windows81-64aulcdfm
@@ -10,7 +10,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-8.1-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x64
       template: win-81-x86_64
       roles:

--- a/test/fixtures/generated/osinfo-version-1/windowsvista-64a
+++ b/test/fixtures/generated/osinfo-version-1/windowsvista-64a
@@ -10,7 +10,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: windows-vista-64
-      packaging_platform: windows-2012-x64
+      packaging_platform: windows-2012r2-x64
       ruby_arch: x64
       template: win-vista-x86_64
       roles:


### PR DESCRIPTION
An arbitrary choice was made to specify windows-2012 as the packaging
platform. In practice we use windows-2012r2, so make this
not-so-arbitrary by matching what we do in practice. Currently this is
breaking puppet-agent component PR testing that expects the packaging
platform to match its own config.