### PR TITLE
(BKR-1308) Add support for amazon7 (Amazon Linux v2)

### DIFF
--- a/lib/beaker-hostgenerator/data.rb
+++ b/lib/beaker-hostgenerator/data.rb
@@ -117,6 +117,15 @@ module BeakerHostGenerator
                 'template' => 'amazon-6-x86_64'
             }
         },
+        'amazon7-64' => {
+            :general => {
+                'platform'           => 'el-7-x86_64',
+                'packaging_platform' => 'el-7-x86_64'
+            },
+            :abs => {
+                'template' => 'amazon-7-x86_64'
+            }
+        },
         'arista4-32' => {
           :general => {
             'platform'           => 'eos-4-i386',

--- a/test/fixtures/generated/default/amazon7-64f
+++ b/test/fixtures/generated/default/amazon7-64f
@@ -1,0 +1,21 @@
+---
+arguments_string: amazon7-64f
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    amazon7-64-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      hypervisor: vmpooler
+      platform: el-7-x86_64
+      packaging_platform: el-7-x86_64
+      roles:
+      - agent
+      - frictionless
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception: 

--- a/test/fixtures/generated/multiplatform/amazon7-64f-windows8-64-amazon7-64l
+++ b/test/fixtures/generated/multiplatform/amazon7-64f-windows8-64-amazon7-64l
@@ -1,0 +1,44 @@
+---
+arguments_string: amazon7-64f-windows8-64-amazon7-64l
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    amazon7-64-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      hypervisor: vmpooler
+      platform: el-7-x86_64
+      packaging_platform: el-7-x86_64
+      roles:
+      - agent
+      - frictionless
+    windows8-64-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      hypervisor: vmpooler
+      platform: windows-8-64
+      packaging_platform: windows-2012-x64
+      ruby_arch: x64
+      template: win-8-x86_64
+      roles:
+      - agent
+    amazon7-64-2:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      hypervisor: vmpooler
+      platform: el-7-x86_64
+      packaging_platform: el-7-x86_64
+      roles:
+      - agent
+      - classifier
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception: 

--- a/test/fixtures/generated/multiplatform/windows8-64u-amazon7-64-windows8-64m
+++ b/test/fixtures/generated/multiplatform/windows8-64u-amazon7-64-windows8-64m
@@ -1,0 +1,46 @@
+---
+arguments_string: windows8-64u-amazon7-64-windows8-64m
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    windows8-64-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      hypervisor: vmpooler
+      platform: windows-8-64
+      packaging_platform: windows-2012-x64
+      ruby_arch: x64
+      template: win-8-x86_64
+      roles:
+      - agent
+      - ca
+    amazon7-64-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      hypervisor: vmpooler
+      platform: el-7-x86_64
+      packaging_platform: el-7-x86_64
+      roles:
+      - agent
+    windows8-64-2:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      hypervisor: vmpooler
+      platform: windows-8-64
+      packaging_platform: windows-2012-x64
+      ruby_arch: x64
+      template: win-8-x86_64
+      roles:
+      - agent
+      - master
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception: 

--- a/test/fixtures/generated/osinfo-version-0/amazon7-64f
+++ b/test/fixtures/generated/osinfo-version-0/amazon7-64f
@@ -1,0 +1,21 @@
+---
+arguments_string: "--osinfo-version 0 amazon7-64f"
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    amazon7-64-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      hypervisor: vmpooler
+      platform: el-7-x86_64
+      packaging_platform: el-7-x86_64
+      roles:
+      - agent
+      - frictionless
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception: 

--- a/test/fixtures/generated/osinfo-version-1/amazon7-64f
+++ b/test/fixtures/generated/osinfo-version-1/amazon7-64f
@@ -1,0 +1,21 @@
+---
+arguments_string: "--osinfo-version 1 amazon7-64f"
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    amazon7-64-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      hypervisor: vmpooler
+      platform: el-7-x86_64
+      packaging_platform: el-7-x86_64
+      roles:
+      - agent
+      - frictionless
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception: 


### PR DESCRIPTION
Amazon Linux v2 is based on el-7-x86_64, and is not packaged as a separate platform - it uses the el-7 package.