### PR TITLE
(maint) Correct the new fips platform to use el-7 as the platform

### DIFF
--- a/lib/beaker-hostgenerator/data.rb
+++ b/lib/beaker-hostgenerator/data.rb
@@ -625,7 +625,7 @@ module BeakerHostGenerator
         },
         'redhatfips7-64' => {
           :general => {
-            'platform'           => 'redhat_fips-7-x86_64',
+            'platform'           => 'el-7-x86_64',
             'packaging_platform' => 'redhat-fips-7-x86_64'
           },
           :vmpooler => {

--- a/test/fixtures/generated/default/redhatfips7-64aulcdfm
+++ b/test/fixtures/generated/default/redhatfips7-64aulcdfm
@@ -9,7 +9,7 @@ expected_hash:
       pe_upgrade_dir: 
       pe_upgrade_ver: 
       hypervisor: vmpooler
-      platform: redhat_fips-7-x86_64
+      platform: el-7-x86_64
       packaging_platform: redhat-fips-7-x86_64
       template: redhat-fips-7-x86_64
       roles:

--- a/test/fixtures/generated/multiplatform/redhatfips7-64aulcdfm-sles10-32-redhatfips7-64a
+++ b/test/fixtures/generated/multiplatform/redhatfips7-64aulcdfm-sles10-32-redhatfips7-64a
@@ -9,7 +9,7 @@ expected_hash:
       pe_upgrade_dir: 
       pe_upgrade_ver: 
       hypervisor: vmpooler
-      platform: redhat_fips-7-x86_64
+      platform: el-7-x86_64
       packaging_platform: redhat-fips-7-x86_64
       template: redhat-fips-7-x86_64
       roles:
@@ -36,7 +36,7 @@ expected_hash:
       pe_upgrade_dir: 
       pe_upgrade_ver: 
       hypervisor: vmpooler
-      platform: redhat_fips-7-x86_64
+      platform: el-7-x86_64
       packaging_platform: redhat-fips-7-x86_64
       template: redhat-fips-7-x86_64
       roles:

--- a/test/fixtures/generated/multiplatform/sles10-32a-redhatfips7-64-sles10-32aulcdfm
+++ b/test/fixtures/generated/multiplatform/sles10-32a-redhatfips7-64-sles10-32aulcdfm
@@ -19,7 +19,7 @@ expected_hash:
       pe_upgrade_dir: 
       pe_upgrade_ver: 
       hypervisor: vmpooler
-      platform: redhat_fips-7-x86_64
+      platform: el-7-x86_64
       packaging_platform: redhat-fips-7-x86_64
       template: redhat-fips-7-x86_64
       roles:

--- a/test/fixtures/generated/osinfo-version-0/redhatfips7-64aulcdfm
+++ b/test/fixtures/generated/osinfo-version-0/redhatfips7-64aulcdfm
@@ -9,7 +9,7 @@ expected_hash:
       pe_upgrade_dir: 
       pe_upgrade_ver: 
       hypervisor: vmpooler
-      platform: redhat_fips-7-x86_64
+      platform: el-7-x86_64
       packaging_platform: redhat-fips-7-x86_64
       template: redhat-fips-7-x86_64
       roles:

--- a/test/fixtures/generated/osinfo-version-1/redhatfips7-64aulcdfm
+++ b/test/fixtures/generated/osinfo-version-1/redhatfips7-64aulcdfm
@@ -9,7 +9,7 @@ expected_hash:
       pe_upgrade_dir: 
       pe_upgrade_ver: 
       hypervisor: vmpooler
-      platform: redhat_fips-7-x86_64
+      platform: el-7-x86_64
       packaging_platform: redhat-fips-7-x86_64
       template: redhat-fips-7-x86_64
       roles:


### PR DESCRIPTION
In order for Beaker to not have to know about all flavors of each OS, we should use el-7-x86_64 as the mapping for the platform and packaging_platform.