### PR TITLE
(PA-1958) Rename redhat-fips packaging_platform to redhatfips

### DIFF
--- a/lib/beaker-hostgenerator/data.rb
+++ b/lib/beaker-hostgenerator/data.rb
@@ -635,7 +635,7 @@ module BeakerHostGenerator
         'redhatfips7-64' => {
           :general => {
             'platform'           => 'el-7-x86_64',
-            'packaging_platform' => 'redhat-fips-7-x86_64'
+            'packaging_platform' => 'redhatfips-7-x86_64'
           },
           :vmpooler => {
             'template' => 'redhat-fips-7-x86_64'

--- a/test/fixtures/generated/default/redhatfips7-64aulcdfm
+++ b/test/fixtures/generated/default/redhatfips7-64aulcdfm
@@ -10,7 +10,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-7-x86_64
-      packaging_platform: redhat-fips-7-x86_64
+      packaging_platform: redhatfips-7-x86_64
       template: redhat-fips-7-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/multiplatform/redhatfips7-64aulcdfm-sles10-32-redhatfips7-64a
+++ b/test/fixtures/generated/multiplatform/redhatfips7-64aulcdfm-sles10-32-redhatfips7-64a
@@ -10,7 +10,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-7-x86_64
-      packaging_platform: redhat-fips-7-x86_64
+      packaging_platform: redhatfips-7-x86_64
       template: redhat-fips-7-x86_64
       roles:
       - agent
@@ -37,7 +37,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-7-x86_64
-      packaging_platform: redhat-fips-7-x86_64
+      packaging_platform: redhatfips-7-x86_64
       template: redhat-fips-7-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/multiplatform/sles10-32a-redhatfips7-64-sles10-32aulcdfm
+++ b/test/fixtures/generated/multiplatform/sles10-32a-redhatfips7-64-sles10-32aulcdfm
@@ -20,7 +20,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-7-x86_64
-      packaging_platform: redhat-fips-7-x86_64
+      packaging_platform: redhatfips-7-x86_64
       template: redhat-fips-7-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/osinfo-version-0/redhatfips7-64aulcdfm
+++ b/test/fixtures/generated/osinfo-version-0/redhatfips7-64aulcdfm
@@ -10,7 +10,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-7-x86_64
-      packaging_platform: redhat-fips-7-x86_64
+      packaging_platform: redhatfips-7-x86_64
       template: redhat-fips-7-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/osinfo-version-1/redhatfips7-64aulcdfm
+++ b/test/fixtures/generated/osinfo-version-1/redhatfips7-64aulcdfm
@@ -10,7 +10,7 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: el-7-x86_64
-      packaging_platform: redhat-fips-7-x86_64
+      packaging_platform: redhatfips-7-x86_64
       template: redhat-fips-7-x86_64
       roles:
       - agent


### PR DESCRIPTION
This change is being made in puppet-agent and related dependencies in
order to make this platform usable in pe_repo.