### PR TITLE
(IMAGES-843) Add Windows Server 2019 Definitions

### DIFF
--- a/lib/beaker-hostgenerator/data.rb
+++ b/lib/beaker-hostgenerator/data.rb
@@ -1339,6 +1339,26 @@ module BeakerHostGenerator
             'template' => 'win-2016-core-x86_64'
           }
         },
+        'windows2019-64' => {
+          :general => {
+            'platform'           => 'windows-2019-64',
+            'packaging_platform' => 'windows-2012-x64',
+            'ruby_arch' => 'x64'
+          },
+          :vmpooler => {
+            'template' => 'win-2019-x86_64'
+          }
+        },
+        'windows2019-6432' => {
+          :general => {
+            'platform'           => 'windows-2019-64',
+            'packaging_platform' => 'windows-2012-x64',
+            'ruby_arch' => 'x86'
+          },
+          :vmpooler => {
+            'template' => 'win-2019-x86_64'
+          }
+        },
         'windows7-64' => {
           :general => {
             'platform'           => 'windows-7-64',


### PR DESCRIPTION
Windows Server 2019 Preview pools have been added to vmpooler so add a
beaker-hostgenerator definition.