### PR TITLE
install iproute2 on ubuntu18.04

### DIFF
--- a/lib/beaker-hostgenerator/data.rb
+++ b/lib/beaker-hostgenerator/data.rb
@@ -1061,7 +1061,7 @@ module BeakerHostGenerator
           :docker => {
             'docker_image_commands' => [
               'systemctl mask getty@tty1.service getty-static.service',
-              'apt-get install -y net-tools wget locales apt-transport-https',
+              'apt-get install -y net-tools wget locales apt-transport-https iproute2',
               'locale-gen en_US.UTF-8',
               'echo LANG=en_US.UTF-8 > /etc/default/locale'
             ]


### PR DESCRIPTION
beaker uses ss to determine open ports/sockets within virtual instances.
ss is provided by iproute2, which isn't installed by default in the
docker containers.