### PR TITLE
(RE-11280) Add a case for release branch PE versions

### DIFF
--- a/lib/beaker-hostgenerator/data.rb
+++ b/lib/beaker-hostgenerator/data.rb
@@ -35,6 +35,8 @@ module BeakerHostGenerator
         then "#{PE_TARBALL_SERVER}/archives/internal/%s/"
       when /#{base_regex}-.*PEZ_.*/
         then "#{PE_TARBALL_SERVER}/%s/feature/ci-ready"
+      when /#{base_regex}-.*-release/
+        then "#{PE_TARBALL_SERVER}/%s/release/ci-ready"
       when /#{base_regex}-.*/
         then "#{PE_TARBALL_SERVER}/%s/ci-ready"
       else

--- a/spec/beaker-hostgenerator/generator_spec.rb
+++ b/spec/beaker-hostgenerator/generator_spec.rb
@@ -93,6 +93,7 @@ module BeakerHostGenerator
       let(:dev_version) { '2017.3.0-rc4-11-g123abcd' }
       let(:dev_version_no_rc) { '2017.3.0-1-g123abcd' }
       let(:pez_version) { '2017.3.0-rc4-11-g123abcd-PEZ_foo' }
+      let(:release_branch_version) { '2018.1.0-rc0-14-g123abcd-release' }
       let(:release_version) { '2017.2.2' }
       let(:rc_version) { '2017.3.0-rc4' }
 
@@ -107,6 +108,10 @@ module BeakerHostGenerator
 
       it "returns archives/internal for an rc version" do
         expect(BeakerHostGenerator::Data.pe_dir(rc_version)).to match(%r{archives/internal/2017\.3})
+      end
+
+      it "returns release/ci-ready for a release branch version" do
+        expect(BeakerHostGenerator::Data.pe_dir(release_branch_version)).to match(%r{2018\.1/release/ci-ready})
       end
 
       it "returns feature/ci-ready for a PEZ version" do


### PR DESCRIPTION
Because PE tarballs are kept in different places depending on whether
they are dev, release, rc candidate, etc, we need to be able to
determine what url to look for them in.

Based on the PE_VERSION info passed to beaker-hostgenerator, the tool
can automatically determine the correct directory to look for PE
tarballs on enterprise.delivery.puppetlabs.net.

Up till now, release branch tarballs were kept in
version.x/release/ci-ready, but had versions like any other dev build.
This made it impossible for the tool to differentiate.

puppetlabs/enterprise-dist@64de625608 began specializing the tarball
name by including -release, similar to how PEZ feature branch tarballs
end up with -PEZ_feature.

If beaker-hostgenerator is now given a
PE_VERSION=2018.1.5-rc0-11-g123abcd-release, it will find the correct
pe_dir for the release branch tarball.