### PR TITLE
(IMAGES-954) Add win-2019-core-x86_64

### DIFF
--- a/lib/beaker-hostgenerator/data.rb
+++ b/lib/beaker-hostgenerator/data.rb
@@ -1401,6 +1401,26 @@ module BeakerHostGenerator
             'template' => 'win-2019-x86_64'
           }
         },
+        'windows2019_core-64' => {
+          :general => {
+            'platform'           => 'windows-2019-64',
+            'packaging_platform' => 'windows-2012-x64',
+            'ruby_arch' => 'x64'
+          },
+          :vmpooler => {
+            'template' => 'win-2019-core-x86_64'
+          }
+        },
+        'windows2019_core-6432' => {
+          :general => {
+            'platform'           => 'windows-2019-64',
+            'packaging_platform' => 'windows-2012-x64',
+            'ruby_arch' => 'x86'
+          },
+          :vmpooler => {
+            'template' => 'win-2019-core-x86_64'
+          }
+        },
         'windows7-64' => {
           :general => {
             'platform'           => 'windows-7-64',


### PR DESCRIPTION
Windows 2019 Core is being added to the pooler, so a new
beaker-hostgenerater is needed.