### PR TITLE
Add a vagrant hypervisor

### DIFF
--- a/lib/beaker-hostgenerator/data.rb
+++ b/lib/beaker-hostgenerator/data.rb
@@ -297,6 +297,9 @@ module BeakerHostGenerator
               'apt-get update && apt-get install -y cron locales-all net-tools wget'
             ],
           },
+          :vagrant => {
+            'box' => 'debian/wheezy64',
+          },
           :vmpooler => {
             'template' => 'debian-7-x86_64'
           }
@@ -321,6 +324,9 @@ module BeakerHostGenerator
               'rm -f /usr/sbin/policy-rc.d',
               'apt-get update && apt-get install -y cron locales-all net-tools wget'
             ]
+          },
+          :vagrant => {
+            'box' => 'debian/jessie64',
           },
           :vmpooler => {
             'template' => 'debian-8-x86_64'
@@ -353,6 +359,9 @@ module BeakerHostGenerator
               'rm -f /usr/sbin/policy-rc.d',
               'apt-get update && apt-get install -y cron locales-all net-tools wget systemd-sysv gnupg'
             ]
+          },
+          :vagrant => {
+            'box' => 'debian/stretch64',
           },
           :vmpooler => {
             'template' => 'debian-9-x86_64'

--- a/lib/beaker-hostgenerator/hypervisor.rb
+++ b/lib/beaker-hostgenerator/hypervisor.rb
@@ -46,6 +46,8 @@ module BeakerHostGenerator
     def self.builtin_hypervisors()
       {
         'vmpooler' => BeakerHostGenerator::Hypervisor::Vmpooler,
+        'vagrant' => BeakerHostGenerator::Hypervisor::Vagrant,
+        'vagrant_libvirt' => BeakerHostGenerator::Hypervisor::Vagrant,
         'docker' => BeakerHostGenerator::Hypervisor::Docker,
         'abs' => BeakerHostGenerator::Hypervisor::ABS
       }
@@ -96,5 +98,6 @@ end
 # hypervisor implementation files.
 require 'beaker-hostgenerator/hypervisor/unknown'
 require 'beaker-hostgenerator/hypervisor/vmpooler'
+require 'beaker-hostgenerator/hypervisor/vagrant'
 require 'beaker-hostgenerator/hypervisor/docker'
 require 'beaker-hostgenerator/hypervisor/abs'

--- a/lib/beaker-hostgenerator/hypervisor/vagrant.rb
+++ b/lib/beaker-hostgenerator/hypervisor/vagrant.rb
@@ -1,0 +1,32 @@
+require 'beaker-hostgenerator/data'
+require 'beaker-hostgenerator/hypervisor'
+require 'deep_merge'
+
+module BeakerHostGenerator
+  module Hypervisor
+    class Vagrant < BeakerHostGenerator::Hypervisor::Interface
+      include BeakerHostGenerator::Data
+
+      def generate_node(node_info, base_config, bhg_version)
+        base_config['hypervisor'] = 'vagrant'
+
+        if node_info['ostype'] =~ /^centos/
+          base_config['box'] = node_info['ostype'].sub(/(\d)/, '/\1')
+        elsif node_info['ostype'] =~ /^fedora/
+          base_config['box'] = node_info['ostype'].sub(/(\d)/, '/\1') + 'cloud-base'
+        else
+          base_config['box'] = "generic/#{node_info['ostype']}"
+        end
+
+        # We don't use this by default
+        base_config['synced_folder'] = 'disabled'
+
+        platform = node_info['platform']
+        platform_info = get_platform_info(bhg_version, platform, :vagrant)
+        base_config.deep_merge! platform_info
+
+        return base_config
+      end
+    end
+  end
+end

--- a/test/fixtures/per-host-settings/every-hypervisor.yaml
+++ b/test/fixtures/per-host-settings/every-hypervisor.yaml
@@ -1,5 +1,5 @@
 ---
-arguments_string: centos6-64m{hypervisor=vmpooler}-debian8-32a{hypervisor=none}-redhat7-64f{hypervisor=abs}-debian9-64a{hypervisor=docker}
+arguments_string: centos6-64m{hypervisor=vmpooler}-debian8-32a{hypervisor=none}-redhat7-64f{hypervisor=abs}-debian9-64a{hypervisor=docker}-ubuntu1804-64{hypervisor=vagrant}-debian7-64{hypervisor=vagrant_libvirt}
 environment_variables: {}
 expected_hash:
   HOSTS:
@@ -52,6 +52,30 @@ expected_hash:
       - cp /bin/true /sbin/agetty
       - rm -f /usr/sbin/policy-rc.d
       - apt-get update && apt-get install -y cron locales-all net-tools wget systemd-sysv gnupg
+      roles:
+      - agent
+    ubuntu1804-64-1:
+      pe_dir:
+      pe_ver:
+      pe_upgrade_dir:
+      pe_upgrade_ver:
+      hypervisor: vagrant
+      box: generic/ubuntu1804
+      synced_folder: disabled
+      platform: ubuntu-18.04-amd64
+      packaging_platform: ubuntu-18.04-amd64
+      roles:
+      - agent
+    debian7-64-1:
+      pe_dir:
+      pe_ver:
+      pe_upgrade_dir:
+      pe_upgrade_ver:
+      hypervisor: vagrant_libvirt
+      box: debian/wheezy64
+      synced_folder: disabled
+      platform: debian-7-amd64
+      packaging_platform: debian-7-amd64
       roles:
       - agent
 


### PR DESCRIPTION
This also adds some base boxes based from the Vagrant Cloud.

Official builds are used for CentOS and Fedora in a generated way. For
Debian Wheezy, Jessie and Stretch 64 bits we also use the official
builds but manually since there's no automated way to map numbers to
releases. For all other platforms we rely on the generic builds which
uses the same naming scheme as our host specs.

We could use the official Ubuntu images in the same way as Debian, but
they're only built for Virtualbox where the generic ones are built for
other provides as well.

This PR is currently here for initial feedback and testing. I know I'll
need to add tests but an initial pass would be appreciated.