### PR TITLE
(maint) Fix --hypervisor vagrant_libvirt

### DIFF
--- a/lib/beaker-hostgenerator/hypervisor/abs.rb
+++ b/lib/beaker-hostgenerator/hypervisor/abs.rb
@@ -15,21 +15,12 @@ module BeakerHostGenerator
       include BeakerHostGenerator::Data
 
       def generate_node(node_info, base_config, bhg_version)
-        base_config['hypervisor'] = 'abs'
-
         # Grab vmpooler data for this platform and any hardware (ABS) data.
         # The assumption here is that these are mutually exclusive; that is,
         # any given platform will have *either* :vmpooler data or :abs data
         # so we're not worried about one overriding the other when we merge
         # the hashes together.
-        platform = node_info['platform']
-        vmpooler_platform_info = get_platform_info(bhg_version, platform, :vmpooler)
-        abs_platform_info = get_platform_info(bhg_version, platform, :abs)
-
-        base_config.deep_merge! vmpooler_platform_info
-        base_config.deep_merge! abs_platform_info
-
-        return base_config
+        return base_generate_node(node_info, base_config, bhg_version, :vmpooler, :abs)
       end
     end
   end

--- a/lib/beaker-hostgenerator/hypervisor/docker.rb
+++ b/lib/beaker-hostgenerator/hypervisor/docker.rb
@@ -8,16 +8,11 @@ module BeakerHostGenerator
       include BeakerHostGenerator::Data
 
       def generate_node(node_info, base_config, bhg_version)
-        base_config['hypervisor'] = 'docker'
         base_config['docker_cmd'] = ['/sbin/init']
         base_config['image'] = node_info['ostype'].sub(/(\d)/, ':\1')
         base_config['image'].sub!(/(\d{2})/, '\1.') if node_info['ostype'] =~ /^ubuntu/
 
-        platform = node_info['platform']
-        platform_info = get_platform_info(bhg_version, platform, :docker)
-        base_config.deep_merge! platform_info
-
-        return base_config
+        return base_generate_node(node_info, base_config, bhg_version, :docker)
       end
     end
   end

--- a/lib/beaker-hostgenerator/hypervisor/unknown.rb
+++ b/lib/beaker-hostgenerator/hypervisor/unknown.rb
@@ -6,16 +6,8 @@ module BeakerHostGenerator::Hypervisor
   class Unknown < BeakerHostGenerator::Hypervisor::Interface
     include BeakerHostGenerator::Data
 
-    def initialize(name)
-      @name = name
-    end
-
     def generate_node(node_info, base_config, bhg_version)
-      platform = node_info['platform']
-      general_info = get_platform_info(bhg_version, platform, :general)
-      base_config.deep_merge! general_info
-      base_config['hypervisor'] = @name
-      return base_config
+      return base_generate_node(node_info, base_config, bhg_version, :general)
     end
   end
 end

--- a/lib/beaker-hostgenerator/hypervisor/vagrant.rb
+++ b/lib/beaker-hostgenerator/hypervisor/vagrant.rb
@@ -8,8 +8,6 @@ module BeakerHostGenerator
       include BeakerHostGenerator::Data
 
       def generate_node(node_info, base_config, bhg_version)
-        base_config['hypervisor'] = 'vagrant'
-
         if node_info['ostype'] =~ /^centos/
           base_config['box'] = node_info['ostype'].sub(/(\d)/, '/\1')
         elsif node_info['ostype'] =~ /^fedora/
@@ -21,11 +19,7 @@ module BeakerHostGenerator
         # We don't use this by default
         base_config['synced_folder'] = 'disabled'
 
-        platform = node_info['platform']
-        platform_info = get_platform_info(bhg_version, platform, :vagrant)
-        base_config.deep_merge! platform_info
-
-        return base_config
+        return base_generate_node(node_info, base_config, bhg_version, :vagrant)
       end
     end
   end

--- a/lib/beaker-hostgenerator/hypervisor/vmpooler.rb
+++ b/lib/beaker-hostgenerator/hypervisor/vmpooler.rb
@@ -15,12 +15,7 @@ module BeakerHostGenerator
       end
 
       def generate_node(node_info, base_config, bhg_version)
-        # set hypervisor
-        base_config['hypervisor'] = 'vmpooler'
-
-        platform = node_info['platform']
-        platform_info = get_platform_info(bhg_version, platform, :vmpooler)
-        base_config.deep_merge! platform_info
+        base_config = base_generate_node(node_info, base_config, bhg_version, :vmpooler)
 
         # Some vmpooler/vsphere platforms have special requirements.
         # We munge the node host config here if that is necessary.

--- a/test/fixtures/per-host-settings/vagrant-hypervisor.yaml
+++ b/test/fixtures/per-host-settings/vagrant-hypervisor.yaml
@@ -1,0 +1,46 @@
+---
+arguments_string: --hypervisor vagrant_libvirt centos6-64m-debian8-32a-redhat7-64a{hypervisor=vagrant}
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    centos6-64-1:
+      pe_dir:
+      pe_ver:
+      pe_upgrade_dir:
+      pe_upgrade_ver:
+      box: centos/6
+      synced_folder: disabled
+      platform: el-6-x86_64
+      packaging_platform: el-6-x86_64
+      hypervisor: vagrant_libvirt
+      roles:
+      - agent
+      - master
+    debian8-32-1:
+      pe_dir:
+      pe_ver:
+      pe_upgrade_dir:
+      pe_upgrade_ver:
+      box: generic/debian8
+      synced_folder: disabled
+      platform: debian-8-i386
+      packaging_platform: debian-8-i386
+      hypervisor: vagrant_libvirt
+      roles:
+      - agent
+    redhat7-64-1:
+      pe_dir:
+      pe_ver:
+      pe_upgrade_dir:
+      pe_upgrade_ver:
+      box: generic/redhat7
+      synced_folder: disabled
+      platform: el-7-x86_64
+      packaging_platform: el-7-x86_64
+      hypervisor: vagrant
+      roles:
+      - agent
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+expected_exception:


### PR DESCRIPTION
Previously the options[:hypervisor] did not end up in the hosts' config.  This refactors the hypervisors in a common method which always copies the original name into the resulting host config. It still prefers the explicit host hypervisor over the command line option.