### PR TITLE
(PA-2387) use el-7-aarch64 as platform for amazon7-ARM64

### DIFF
--- a/lib/beaker-hostgenerator/data.rb
+++ b/lib/beaker-hostgenerator/data.rb
@@ -128,8 +128,8 @@ module BeakerHostGenerator
         },
         'amazon7-ARM64' => {
           :general => {
-            'platform'           => 'el-7-arm64',
-            'packaging_platform' => 'el-7-arm64'
+            'platform'           => 'el-7-aarch64',
+            'packaging_platform' => 'el-7-aarch64'
           },
           :abs => {
             'template' => 'amazon-7-arm64'

--- a/test/fixtures/generated/multiplatform/amazon7-ARM64m-windows7-64-amazon7-ARM64u
+++ b/test/fixtures/generated/multiplatform/amazon7-ARM64m-windows7-64-amazon7-ARM64u
@@ -8,9 +8,9 @@ expected_hash:
       pe_ver: 
       pe_upgrade_dir: 
       pe_upgrade_ver: 
+      platform: el-7-aarch64
+      packaging_platform: el-7-aarch64
       hypervisor: vmpooler
-      platform: el-7-arm64
-      packaging_platform: el-7-arm64
       roles:
       - agent
       - master
@@ -19,11 +19,11 @@ expected_hash:
       pe_ver: 
       pe_upgrade_dir: 
       pe_upgrade_ver: 
-      hypervisor: vmpooler
       platform: windows-7-64
       packaging_platform: windows-2012-x64
       ruby_arch: x64
       template: win-7-x86_64
+      hypervisor: vmpooler
       roles:
       - agent
     amazon7-ARM64-2:
@@ -31,9 +31,9 @@ expected_hash:
       pe_ver: 
       pe_upgrade_dir: 
       pe_upgrade_ver: 
+      platform: el-7-aarch64
+      packaging_platform: el-7-aarch64
       hypervisor: vmpooler
-      platform: el-7-arm64
-      packaging_platform: el-7-arm64
       roles:
       - agent
       - ca

--- a/test/fixtures/generated/osinfo-version-0/amazon7-ARM64m
+++ b/test/fixtures/generated/osinfo-version-0/amazon7-ARM64m
@@ -8,9 +8,9 @@ expected_hash:
       pe_ver: 
       pe_upgrade_dir: 
       pe_upgrade_ver: 
+      platform: el-7-aarch64
+      packaging_platform: el-7-aarch64
       hypervisor: vmpooler
-      platform: el-7-arm64
-      packaging_platform: el-7-arm64
       roles:
       - agent
       - master

--- a/test/fixtures/generated/osinfo-version-1/amazon7-ARM64m
+++ b/test/fixtures/generated/osinfo-version-1/amazon7-ARM64m
@@ -1,5 +1,5 @@
 ---
-arguments_string: amazon7-ARM64m
+arguments_string: "--osinfo-version 1 amazon7-ARM64m"
 environment_variables: {}
 expected_hash:
   HOSTS:


### PR DESCRIPTION
There is no platform(el-7-arm64) defined in puppet so we cannot build on that.
Build the packages for amazon7-ARM64 on el-7-aarch64 and test them on amazon7-ARM64.
I still need an opinion on this. Does it look ok?


adhoc build: https://jenkins-platform.delivery.puppetlabs.net/view/Adhoc/job/platform_puppet-agent-extra_puppet-agent-integration-suite_adhoc-ad_hoc/518/