### PR TITLE
(QENG-7134) Individualize cisco IOS platforms

### DIFF
--- a/lib/beaker-hostgenerator/data.rb
+++ b/lib/beaker-hostgenerator/data.rb
@@ -252,7 +252,7 @@ module BeakerHostGenerator
             'template' => 'cisco-nxos_hw-9k-x86_64'
           }
         },
-        'ciscoios-32' => {
+        'ciscoiosc2960-ARM32' => {
           :general => {
             'platform' => 'cisco_ios-12-arm32',
             'ssh' => {
@@ -260,10 +260,65 @@ module BeakerHostGenerator
             }
           },
           :abs => {
-            'template' => 'cisco-ios-12-arm'
+            'template' => 'cisco-iosc2960-arm'
           }
         },
-        'ciscoiosxe-32' => {
+        'ciscoiosc3750-ARM32' => {
+          :general => {
+            'platform' => 'cisco_ios-12-arm32',
+            'ssh' => {
+              'user' => 'admin'
+            }
+          },
+          :abs => {
+            'template' => 'cisco-iosc3750-arm'
+          }
+        },
+        'ciscoiosc4507r-ARM32' => {
+          :general => {
+            'platform' => 'cisco_ios-12-arm32',
+            'ssh' => {
+              'user' => 'admin'
+            }
+          },
+          :abs => {
+            'template' => 'cisco-iosc4507r-arm'
+          }
+        },
+        'ciscoiosc4948-ARM32' => {
+          :general => {
+            'platform' => 'cisco_ios-12-arm32',
+            'ssh' => {
+              'user' => 'admin'
+            }
+          },
+          :abs => {
+            'template' => 'cisco-iosc4948-arm'
+          }
+        },
+        'ciscoiosc6503-ARM32' => {
+          :general => {
+            'platform' => 'cisco_ios-12-arm32',
+            'ssh' => {
+              'user' => 'admin'
+            }
+          },
+          :abs => {
+            'template' => 'cisco-iosc6503-arm'
+          }
+        },
+        'ciscoiosxec3605-ARM32' => {
+          :general => {
+            'platform' => 'cisco_iosxec3605-arm32',
+            'ssh' => {
+              'user' => 'admin'
+            }
+          },
+          :abs => {
+            'template' => 'cisco-iosxec3605-arm'
+          }
+        },
+        'ciscoiosxec4503-ARM32' => {
           :general => {
             'platform' => 'cisco_iosxe-3-arm32',
             'ssh' => {
@@ -271,7 +326,7 @@ module BeakerHostGenerator
             }
           },
           :abs => {
-            'template' => 'cisco-iosxe-3-arm'
+            'template' => 'cisco-iosxec4503-arm'
           }
         },
         'ciscoxr-64' => {

--- a/test/fixtures/generated/default/ciscoiosc2960-ARM32u
+++ b/test/fixtures/generated/default/ciscoiosc2960-ARM32u
@@ -1,0 +1,22 @@
+---
+arguments_string: ciscoiosc2960-ARM32u
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    ciscoiosc2960-ARM32-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      platform: cisco_ios-12-arm32
+      ssh:
+        user: admin
+      hypervisor: vmpooler
+      roles:
+      - agent
+      - ca
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception: 

--- a/test/fixtures/generated/default/ciscoiosc3750-ARM32l
+++ b/test/fixtures/generated/default/ciscoiosc3750-ARM32l
@@ -1,0 +1,22 @@
+---
+arguments_string: ciscoiosc3750-ARM32l
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    ciscoiosc3750-ARM32-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      platform: cisco_ios-12-arm32
+      ssh:
+        user: admin
+      hypervisor: vmpooler
+      roles:
+      - agent
+      - classifier
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception: 

--- a/test/fixtures/generated/default/ciscoiosc4507r-ARM32c
+++ b/test/fixtures/generated/default/ciscoiosc4507r-ARM32c
@@ -1,0 +1,22 @@
+---
+arguments_string: ciscoiosc4507r-ARM32c
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    ciscoiosc4507r-ARM32-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      platform: cisco_ios-12-arm32
+      ssh:
+        user: admin
+      hypervisor: vmpooler
+      roles:
+      - agent
+      - dashboard
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception: 

--- a/test/fixtures/generated/default/ciscoiosc4948-ARM32d
+++ b/test/fixtures/generated/default/ciscoiosc4948-ARM32d
@@ -1,0 +1,22 @@
+---
+arguments_string: ciscoiosc4948-ARM32d
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    ciscoiosc4948-ARM32-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      platform: cisco_ios-12-arm32
+      ssh:
+        user: admin
+      hypervisor: vmpooler
+      roles:
+      - agent
+      - database
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception: 

--- a/test/fixtures/generated/default/ciscoiosc6503-ARM32f
+++ b/test/fixtures/generated/default/ciscoiosc6503-ARM32f
@@ -1,0 +1,22 @@
+---
+arguments_string: ciscoiosc6503-ARM32f
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    ciscoiosc6503-ARM32-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      platform: cisco_ios-12-arm32
+      ssh:
+        user: admin
+      hypervisor: vmpooler
+      roles:
+      - agent
+      - frictionless
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception: 

--- a/test/fixtures/generated/default/ciscoiosxec3605-ARM32m
+++ b/test/fixtures/generated/default/ciscoiosxec3605-ARM32m
@@ -1,0 +1,22 @@
+---
+arguments_string: ciscoiosxec3605-ARM32m
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    ciscoiosxec3605-ARM32-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      platform: cisco_iosxec3605-arm32
+      ssh:
+        user: admin
+      hypervisor: vmpooler
+      roles:
+      - agent
+      - master
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception: 

--- a/test/fixtures/generated/default/ciscoiosxec4503-ARM32aulcdfm
+++ b/test/fixtures/generated/default/ciscoiosxec4503-ARM32aulcdfm
@@ -1,0 +1,27 @@
+---
+arguments_string: ciscoiosxec4503-ARM32aulcdfm
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    ciscoiosxec4503-ARM32-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      platform: cisco_iosxe-3-arm32
+      ssh:
+        user: admin
+      hypervisor: vmpooler
+      roles:
+      - agent
+      - ca
+      - classifier
+      - dashboard
+      - database
+      - frictionless
+      - master
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception: 

--- a/test/fixtures/generated/multiplatform/ciscoiosc2960-ARM32u-windows2012r2_core-6432-ciscoiosc2960-ARM32m
+++ b/test/fixtures/generated/multiplatform/ciscoiosc2960-ARM32u-windows2012r2_core-6432-ciscoiosc2960-ARM32m
@@ -1,0 +1,46 @@
+---
+arguments_string: ciscoiosc2960-ARM32u-windows2012r2_core-6432-ciscoiosc2960-ARM32m
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    ciscoiosc2960-ARM32-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      platform: cisco_ios-12-arm32
+      ssh:
+        user: admin
+      hypervisor: vmpooler
+      roles:
+      - agent
+      - ca
+    windows2012r2_core-6432-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      platform: windows-2012r2-64
+      packaging_platform: windows-2012-x64
+      ruby_arch: x86
+      template: win-2012r2-core-x86_64
+      hypervisor: vmpooler
+      roles:
+      - agent
+    ciscoiosc2960-ARM32-2:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      platform: cisco_ios-12-arm32
+      ssh:
+        user: admin
+      hypervisor: vmpooler
+      roles:
+      - agent
+      - master
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception: 

--- a/test/fixtures/generated/multiplatform/ciscoiosc3750-ARM32l-windows2012r2_core-64-ciscoiosc3750-ARM32f
+++ b/test/fixtures/generated/multiplatform/ciscoiosc3750-ARM32l-windows2012r2_core-64-ciscoiosc3750-ARM32f
@@ -1,0 +1,46 @@
+---
+arguments_string: ciscoiosc3750-ARM32l-windows2012r2_core-64-ciscoiosc3750-ARM32f
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    ciscoiosc3750-ARM32-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      platform: cisco_ios-12-arm32
+      ssh:
+        user: admin
+      hypervisor: vmpooler
+      roles:
+      - agent
+      - classifier
+    windows2012r2_core-64-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      platform: windows-2012r2-64
+      packaging_platform: windows-2012-x64
+      ruby_arch: x64
+      template: win-2012r2-core-x86_64
+      hypervisor: vmpooler
+      roles:
+      - agent
+    ciscoiosc3750-ARM32-2:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      platform: cisco_ios-12-arm32
+      ssh:
+        user: admin
+      hypervisor: vmpooler
+      roles:
+      - agent
+      - frictionless
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception: 

--- a/test/fixtures/generated/multiplatform/ciscoiosc4507r-ARM32c-windows2012r2_fr-6432-ciscoiosc4507r-ARM32d
+++ b/test/fixtures/generated/multiplatform/ciscoiosc4507r-ARM32c-windows2012r2_fr-6432-ciscoiosc4507r-ARM32d
@@ -1,0 +1,47 @@
+---
+arguments_string: ciscoiosc4507r-ARM32c-windows2012r2_fr-6432-ciscoiosc4507r-ARM32d
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    ciscoiosc4507r-ARM32-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      platform: cisco_ios-12-arm32
+      ssh:
+        user: admin
+      hypervisor: vmpooler
+      roles:
+      - agent
+      - dashboard
+    windows2012r2_fr-6432-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      platform: windows-2012r2-64
+      packaging_platform: windows-2012-x64
+      ruby_arch: x86
+      template: win-2012r2-fr-x86_64
+      user: Administrateur
+      hypervisor: vmpooler
+      roles:
+      - agent
+    ciscoiosc4507r-ARM32-2:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      platform: cisco_ios-12-arm32
+      ssh:
+        user: admin
+      hypervisor: vmpooler
+      roles:
+      - agent
+      - database
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception: 

--- a/test/fixtures/generated/multiplatform/ciscoiosc4948-ARM32d-windows2012r2_fr-64-ciscoiosc4948-ARM32c
+++ b/test/fixtures/generated/multiplatform/ciscoiosc4948-ARM32d-windows2012r2_fr-64-ciscoiosc4948-ARM32c
@@ -1,0 +1,47 @@
+---
+arguments_string: ciscoiosc4948-ARM32d-windows2012r2_fr-64-ciscoiosc4948-ARM32c
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    ciscoiosc4948-ARM32-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      platform: cisco_ios-12-arm32
+      ssh:
+        user: admin
+      hypervisor: vmpooler
+      roles:
+      - agent
+      - database
+    windows2012r2_fr-64-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      platform: windows-2012r2-64
+      packaging_platform: windows-2012-x64
+      ruby_arch: x64
+      template: win-2012r2-fr-x86_64
+      user: Administrateur
+      hypervisor: vmpooler
+      roles:
+      - agent
+    ciscoiosc4948-ARM32-2:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      platform: cisco_ios-12-arm32
+      ssh:
+        user: admin
+      hypervisor: vmpooler
+      roles:
+      - agent
+      - dashboard
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception: 

--- a/test/fixtures/generated/multiplatform/ciscoiosc6503-ARM32f-windows2012r2_ja-6432-ciscoiosc6503-ARM32l
+++ b/test/fixtures/generated/multiplatform/ciscoiosc6503-ARM32f-windows2012r2_ja-6432-ciscoiosc6503-ARM32l
@@ -1,0 +1,46 @@
+---
+arguments_string: ciscoiosc6503-ARM32f-windows2012r2_ja-6432-ciscoiosc6503-ARM32l
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    ciscoiosc6503-ARM32-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      platform: cisco_ios-12-arm32
+      ssh:
+        user: admin
+      hypervisor: vmpooler
+      roles:
+      - agent
+      - frictionless
+    windows2012r2_ja-6432-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      platform: windows-2012r2-64
+      packaging_platform: windows-2012-x64
+      ruby_arch: x86
+      template: win-2012r2-ja-x86_64
+      hypervisor: vmpooler
+      roles:
+      - agent
+    ciscoiosc6503-ARM32-2:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      platform: cisco_ios-12-arm32
+      ssh:
+        user: admin
+      hypervisor: vmpooler
+      roles:
+      - agent
+      - classifier
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception: 

--- a/test/fixtures/generated/multiplatform/ciscoiosxec3605-ARM32m-windows2012r2_ja-64-ciscoiosxec3605-ARM32u
+++ b/test/fixtures/generated/multiplatform/ciscoiosxec3605-ARM32m-windows2012r2_ja-64-ciscoiosxec3605-ARM32u
@@ -1,0 +1,46 @@
+---
+arguments_string: ciscoiosxec3605-ARM32m-windows2012r2_ja-64-ciscoiosxec3605-ARM32u
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    ciscoiosxec3605-ARM32-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      platform: cisco_iosxec3605-arm32
+      ssh:
+        user: admin
+      hypervisor: vmpooler
+      roles:
+      - agent
+      - master
+    windows2012r2_ja-64-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      platform: windows-2012r2-64
+      packaging_platform: windows-2012-x64
+      ruby_arch: x64
+      template: win-2012r2-ja-x86_64
+      hypervisor: vmpooler
+      roles:
+      - agent
+    ciscoiosxec3605-ARM32-2:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      platform: cisco_iosxec3605-arm32
+      ssh:
+        user: admin
+      hypervisor: vmpooler
+      roles:
+      - agent
+      - ca
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception: 

--- a/test/fixtures/generated/multiplatform/ciscoiosxec4503-ARM32aulcdfm-windows2012r2_wmf5-64-ciscoiosxec4503-ARM32a
+++ b/test/fixtures/generated/multiplatform/ciscoiosxec4503-ARM32aulcdfm-windows2012r2_wmf5-64-ciscoiosxec4503-ARM32a
@@ -1,0 +1,50 @@
+---
+arguments_string: ciscoiosxec4503-ARM32aulcdfm-windows2012r2_wmf5-64-ciscoiosxec4503-ARM32a
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    ciscoiosxec4503-ARM32-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      platform: cisco_iosxe-3-arm32
+      ssh:
+        user: admin
+      hypervisor: vmpooler
+      roles:
+      - agent
+      - ca
+      - classifier
+      - dashboard
+      - database
+      - frictionless
+      - master
+    windows2012r2_wmf5-64-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      platform: windows-2012r2-64
+      packaging_platform: windows-2012-x64
+      ruby_arch: x64
+      template: win-2012r2-wmf5-x86_64
+      hypervisor: vmpooler
+      roles:
+      - agent
+    ciscoiosxec4503-ARM32-2:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      platform: cisco_iosxe-3-arm32
+      ssh:
+        user: admin
+      hypervisor: vmpooler
+      roles:
+      - agent
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception: 

--- a/test/fixtures/generated/osinfo-version-0/ciscoiosc2960-ARM32u
+++ b/test/fixtures/generated/osinfo-version-0/ciscoiosc2960-ARM32u
@@ -1,0 +1,22 @@
+---
+arguments_string: "--osinfo-version 0 ciscoiosc2960-ARM32u"
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    ciscoiosc2960-ARM32-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      platform: cisco_ios-12-arm32
+      ssh:
+        user: admin
+      hypervisor: vmpooler
+      roles:
+      - agent
+      - ca
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception: 

--- a/test/fixtures/generated/osinfo-version-0/ciscoiosc3750-ARM32l
+++ b/test/fixtures/generated/osinfo-version-0/ciscoiosc3750-ARM32l
@@ -1,0 +1,22 @@
+---
+arguments_string: "--osinfo-version 0 ciscoiosc3750-ARM32l"
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    ciscoiosc3750-ARM32-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      platform: cisco_ios-12-arm32
+      ssh:
+        user: admin
+      hypervisor: vmpooler
+      roles:
+      - agent
+      - classifier
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception: 

--- a/test/fixtures/generated/osinfo-version-0/ciscoiosc4507r-ARM32c
+++ b/test/fixtures/generated/osinfo-version-0/ciscoiosc4507r-ARM32c
@@ -1,0 +1,22 @@
+---
+arguments_string: "--osinfo-version 0 ciscoiosc4507r-ARM32c"
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    ciscoiosc4507r-ARM32-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      platform: cisco_ios-12-arm32
+      ssh:
+        user: admin
+      hypervisor: vmpooler
+      roles:
+      - agent
+      - dashboard
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception: 

--- a/test/fixtures/generated/osinfo-version-0/ciscoiosc4948-ARM32d
+++ b/test/fixtures/generated/osinfo-version-0/ciscoiosc4948-ARM32d
@@ -1,0 +1,22 @@
+---
+arguments_string: "--osinfo-version 0 ciscoiosc4948-ARM32d"
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    ciscoiosc4948-ARM32-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      platform: cisco_ios-12-arm32
+      ssh:
+        user: admin
+      hypervisor: vmpooler
+      roles:
+      - agent
+      - database
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception: 

--- a/test/fixtures/generated/osinfo-version-0/ciscoiosc6503-ARM32f
+++ b/test/fixtures/generated/osinfo-version-0/ciscoiosc6503-ARM32f
@@ -1,0 +1,22 @@
+---
+arguments_string: "--osinfo-version 0 ciscoiosc6503-ARM32f"
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    ciscoiosc6503-ARM32-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      platform: cisco_ios-12-arm32
+      ssh:
+        user: admin
+      hypervisor: vmpooler
+      roles:
+      - agent
+      - frictionless
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception: 

--- a/test/fixtures/generated/osinfo-version-0/ciscoiosxec3605-ARM32m
+++ b/test/fixtures/generated/osinfo-version-0/ciscoiosxec3605-ARM32m
@@ -1,0 +1,22 @@
+---
+arguments_string: "--osinfo-version 0 ciscoiosxec3605-ARM32m"
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    ciscoiosxec3605-ARM32-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      platform: cisco_iosxec3605-arm32
+      ssh:
+        user: admin
+      hypervisor: vmpooler
+      roles:
+      - agent
+      - master
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception: 

--- a/test/fixtures/generated/osinfo-version-0/ciscoiosxec4503-ARM32aulcdfm
+++ b/test/fixtures/generated/osinfo-version-0/ciscoiosxec4503-ARM32aulcdfm
@@ -1,0 +1,27 @@
+---
+arguments_string: "--osinfo-version 0 ciscoiosxec4503-ARM32aulcdfm"
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    ciscoiosxec4503-ARM32-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      platform: cisco_iosxe-3-arm32
+      ssh:
+        user: admin
+      hypervisor: vmpooler
+      roles:
+      - agent
+      - ca
+      - classifier
+      - dashboard
+      - database
+      - frictionless
+      - master
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception: 

--- a/test/fixtures/generated/osinfo-version-1/ciscoiosc2960-ARM32u
+++ b/test/fixtures/generated/osinfo-version-1/ciscoiosc2960-ARM32u
@@ -1,0 +1,22 @@
+---
+arguments_string: "--osinfo-version 1 ciscoiosc2960-ARM32u"
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    ciscoiosc2960-ARM32-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      platform: cisco_ios-12-arm32
+      ssh:
+        user: admin
+      hypervisor: vmpooler
+      roles:
+      - agent
+      - ca
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception: 

--- a/test/fixtures/generated/osinfo-version-1/ciscoiosc3750-ARM32l
+++ b/test/fixtures/generated/osinfo-version-1/ciscoiosc3750-ARM32l
@@ -1,0 +1,22 @@
+---
+arguments_string: "--osinfo-version 1 ciscoiosc3750-ARM32l"
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    ciscoiosc3750-ARM32-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      platform: cisco_ios-12-arm32
+      ssh:
+        user: admin
+      hypervisor: vmpooler
+      roles:
+      - agent
+      - classifier
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception: 

--- a/test/fixtures/generated/osinfo-version-1/ciscoiosc4507r-ARM32c
+++ b/test/fixtures/generated/osinfo-version-1/ciscoiosc4507r-ARM32c
@@ -1,0 +1,22 @@
+---
+arguments_string: "--osinfo-version 1 ciscoiosc4507r-ARM32c"
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    ciscoiosc4507r-ARM32-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      platform: cisco_ios-12-arm32
+      ssh:
+        user: admin
+      hypervisor: vmpooler
+      roles:
+      - agent
+      - dashboard
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception: 

--- a/test/fixtures/generated/osinfo-version-1/ciscoiosc4948-ARM32d
+++ b/test/fixtures/generated/osinfo-version-1/ciscoiosc4948-ARM32d
@@ -1,0 +1,22 @@
+---
+arguments_string: "--osinfo-version 1 ciscoiosc4948-ARM32d"
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    ciscoiosc4948-ARM32-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      platform: cisco_ios-12-arm32
+      ssh:
+        user: admin
+      hypervisor: vmpooler
+      roles:
+      - agent
+      - database
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception: 

--- a/test/fixtures/generated/osinfo-version-1/ciscoiosc6503-ARM32f
+++ b/test/fixtures/generated/osinfo-version-1/ciscoiosc6503-ARM32f
@@ -1,0 +1,22 @@
+---
+arguments_string: "--osinfo-version 1 ciscoiosc6503-ARM32f"
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    ciscoiosc6503-ARM32-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      platform: cisco_ios-12-arm32
+      ssh:
+        user: admin
+      hypervisor: vmpooler
+      roles:
+      - agent
+      - frictionless
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception: 

--- a/test/fixtures/generated/osinfo-version-1/ciscoiosxec3605-ARM32m
+++ b/test/fixtures/generated/osinfo-version-1/ciscoiosxec3605-ARM32m
@@ -1,0 +1,22 @@
+---
+arguments_string: "--osinfo-version 1 ciscoiosxec3605-ARM32m"
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    ciscoiosxec3605-ARM32-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      platform: cisco_iosxec3605-arm32
+      ssh:
+        user: admin
+      hypervisor: vmpooler
+      roles:
+      - agent
+      - master
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception: 

--- a/test/fixtures/generated/osinfo-version-1/ciscoiosxec4503-ARM32aulcdfm
+++ b/test/fixtures/generated/osinfo-version-1/ciscoiosxec4503-ARM32aulcdfm
@@ -1,0 +1,27 @@
+---
+arguments_string: "--osinfo-version 1 ciscoiosxec4503-ARM32aulcdfm"
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    ciscoiosxec4503-ARM32-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      platform: cisco_iosxe-3-arm32
+      ssh:
+        user: admin
+      hypervisor: vmpooler
+      roles:
+      - agent
+      - ca
+      - classifier
+      - dashboard
+      - database
+      - frictionless
+      - master
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception: 


### PR DESCRIPTION
Before, these were all managed by one pool. These need to be called
individually based on their version number so there are now
separate calls for each version for cisco ios.

Additionally, made it clear that these are ARM32 hardware devices.