### PR TITLE
(IMAGES-1116) Add beaker-hostgenerator support for Fedora 30 (amd64)

### DIFF
--- a/lib/beaker-hostgenerator/data.rb
+++ b/lib/beaker-hostgenerator/data.rb
@@ -631,6 +631,15 @@ module BeakerHostGenerator
             'template' => 'fedora-29-x86_64'
           }
         },
+        'fedora30-64' => {
+          :general => {
+            'platform'           => 'fedora-30-x86_64',
+            'packaging_platform' => 'fedora-30-x86_64'
+          },
+          :vmpooler => {
+            'template' => 'fedora-30-x86_64'
+          }
+        },
         'huaweios6-POWER' => {
           :general => {
             'platform' => 'huaweios-6-powerpc'

--- a/test/fixtures/generated/default/fedora30-64aulcdfm
+++ b/test/fixtures/generated/default/fedora30-64aulcdfm
@@ -1,0 +1,27 @@
+---
+arguments_string: fedora30-64aulcdfm
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    fedora30-64-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      platform: fedora-30-x86_64
+      packaging_platform: fedora-30-x86_64
+      template: fedora-30-x86_64
+      hypervisor: vmpooler
+      roles:
+      - agent
+      - ca
+      - classifier
+      - dashboard
+      - database
+      - frictionless
+      - master
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception: 

--- a/test/fixtures/generated/multiplatform/fedora30-64aulcdfm-ubuntu1204-64-fedora30-64a
+++ b/test/fixtures/generated/multiplatform/fedora30-64aulcdfm-ubuntu1204-64-fedora30-64a
@@ -1,0 +1,48 @@
+---
+arguments_string: fedora30-64aulcdfm-ubuntu1204-64-fedora30-64a
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    fedora30-64-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      platform: fedora-30-x86_64
+      packaging_platform: fedora-30-x86_64
+      template: fedora-30-x86_64
+      hypervisor: vmpooler
+      roles:
+      - agent
+      - ca
+      - classifier
+      - dashboard
+      - database
+      - frictionless
+      - master
+    ubuntu1204-64-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      platform: ubuntu-12.04-amd64
+      template: ubuntu-1204-x86_64
+      hypervisor: vmpooler
+      roles:
+      - agent
+    fedora30-64-2:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      platform: fedora-30-x86_64
+      packaging_platform: fedora-30-x86_64
+      template: fedora-30-x86_64
+      hypervisor: vmpooler
+      roles:
+      - agent
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception: 

--- a/test/fixtures/generated/multiplatform/ubuntu1204-64u-fedora30-64-ubuntu1204-64m
+++ b/test/fixtures/generated/multiplatform/ubuntu1204-64u-fedora30-64-ubuntu1204-64m
@@ -1,0 +1,43 @@
+---
+arguments_string: ubuntu1204-64u-fedora30-64-ubuntu1204-64m
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    ubuntu1204-64-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      platform: ubuntu-12.04-amd64
+      template: ubuntu-1204-x86_64
+      hypervisor: vmpooler
+      roles:
+      - agent
+      - ca
+    fedora30-64-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      platform: fedora-30-x86_64
+      packaging_platform: fedora-30-x86_64
+      template: fedora-30-x86_64
+      hypervisor: vmpooler
+      roles:
+      - agent
+    ubuntu1204-64-2:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      platform: ubuntu-12.04-amd64
+      template: ubuntu-1204-x86_64
+      hypervisor: vmpooler
+      roles:
+      - agent
+      - master
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception: 

--- a/test/fixtures/generated/osinfo-version-0/fedora30-64aulcdfm
+++ b/test/fixtures/generated/osinfo-version-0/fedora30-64aulcdfm
@@ -1,0 +1,27 @@
+---
+arguments_string: "--osinfo-version 0 fedora30-64aulcdfm"
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    fedora30-64-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      platform: fedora-30-x86_64
+      packaging_platform: fedora-30-x86_64
+      template: fedora-30-x86_64
+      hypervisor: vmpooler
+      roles:
+      - agent
+      - ca
+      - classifier
+      - dashboard
+      - database
+      - frictionless
+      - master
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception: 

--- a/test/fixtures/generated/osinfo-version-1/fedora30-64aulcdfm
+++ b/test/fixtures/generated/osinfo-version-1/fedora30-64aulcdfm
@@ -1,0 +1,27 @@
+---
+arguments_string: "--osinfo-version 1 fedora30-64aulcdfm"
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    fedora30-64-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      platform: fedora-30-x86_64
+      packaging_platform: fedora-30-x86_64
+      template: fedora-30-x86_64
+      hypervisor: vmpooler
+      roles:
+      - agent
+      - ca
+      - classifier
+      - dashboard
+      - database
+      - frictionless
+      - master
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception: 


### PR DESCRIPTION
- [x] Add the platform to data.rb
- [x] Run rake task to generate fixtures (like 500+ of them)
- [x] Git commit only the fixtures that have the new platform in them (and delete the other created/changed fixtures)