### PR TITLE
(QENG-6980) Fix name for c3650

### DIFF
--- a/lib/beaker-hostgenerator/data.rb
+++ b/lib/beaker-hostgenerator/data.rb
@@ -307,15 +307,15 @@ module BeakerHostGenerator
             'template' => 'cisco-iosc6503-arm'
           }
         },
-        'ciscoiosxec3605-ARM32' => {
+        'ciscoiosxec3650-ARM32' => {
           :general => {
-            'platform' => 'cisco_iosxec3605-arm32',
+            'platform' => 'cisco_iosxec3650-arm32',
             'ssh' => {
               'user' => 'admin'
             }
           },
           :abs => {
-            'template' => 'cisco-iosxec3605-arm'
+            'template' => 'cisco-iosxec3650-arm'
           }
         },
         'ciscoiosxec4503-ARM32' => {

--- a/test/fixtures/generated/default/ciscoiosxec3650-ARM32m
+++ b/test/fixtures/generated/default/ciscoiosxec3650-ARM32m
@@ -1,14 +1,14 @@
 ---
-arguments_string: "--osinfo-version 0 ciscoiosxec3605-ARM32m"
+arguments_string: ciscoiosxec3650-ARM32m
 environment_variables: {}
 expected_hash:
   HOSTS:
-    ciscoiosxec3605-ARM32-1:
+    ciscoiosxec3650-ARM32-1:
       pe_dir: 
       pe_ver: 
       pe_upgrade_dir: 
       pe_upgrade_ver: 
-      platform: cisco_iosxec3605-arm32
+      platform: cisco_iosxec3650-arm32
       ssh:
         user: admin
       hypervisor: vmpooler

--- a/test/fixtures/generated/multiplatform/ciscoiosxec3650-ARM32m-windows2012r2_ja-64-ciscoiosxec3650-ARM32u
+++ b/test/fixtures/generated/multiplatform/ciscoiosxec3650-ARM32m-windows2012r2_ja-64-ciscoiosxec3650-ARM32u
@@ -1,14 +1,14 @@
 ---
-arguments_string: ciscoiosxec3605-ARM32m-windows2012r2_ja-64-ciscoiosxec3605-ARM32u
+arguments_string: ciscoiosxec3650-ARM32m-windows2012r2_ja-64-ciscoiosxec3650-ARM32u
 environment_variables: {}
 expected_hash:
   HOSTS:
-    ciscoiosxec3605-ARM32-1:
+    ciscoiosxec3650-ARM32-1:
       pe_dir: 
       pe_ver: 
       pe_upgrade_dir: 
       pe_upgrade_ver: 
-      platform: cisco_iosxec3605-arm32
+      platform: cisco_iosxec3650-arm32
       ssh:
         user: admin
       hypervisor: vmpooler
@@ -27,12 +27,12 @@ expected_hash:
       hypervisor: vmpooler
       roles:
       - agent
-    ciscoiosxec3605-ARM32-2:
+    ciscoiosxec3650-ARM32-2:
       pe_dir: 
       pe_ver: 
       pe_upgrade_dir: 
       pe_upgrade_ver: 
-      platform: cisco_iosxec3605-arm32
+      platform: cisco_iosxec3650-arm32
       ssh:
         user: admin
       hypervisor: vmpooler

--- a/test/fixtures/generated/osinfo-version-0/ciscoiosxec3650-ARM32m
+++ b/test/fixtures/generated/osinfo-version-0/ciscoiosxec3650-ARM32m
@@ -1,14 +1,14 @@
 ---
-arguments_string: "--osinfo-version 1 ciscoiosxec3605-ARM32m"
+arguments_string: "--osinfo-version 0 ciscoiosxec3650-ARM32m"
 environment_variables: {}
 expected_hash:
   HOSTS:
-    ciscoiosxec3605-ARM32-1:
+    ciscoiosxec3650-ARM32-1:
       pe_dir: 
       pe_ver: 
       pe_upgrade_dir: 
       pe_upgrade_ver: 
-      platform: cisco_iosxec3605-arm32
+      platform: cisco_iosxec3650-arm32
       ssh:
         user: admin
       hypervisor: vmpooler

--- a/test/fixtures/generated/osinfo-version-1/ciscoiosxec3650-ARM32m
+++ b/test/fixtures/generated/osinfo-version-1/ciscoiosxec3650-ARM32m
@@ -1,14 +1,14 @@
 ---
-arguments_string: ciscoiosxec3605-ARM32m
+arguments_string: "--osinfo-version 1 ciscoiosxec3650-ARM32m"
 environment_variables: {}
 expected_hash:
   HOSTS:
-    ciscoiosxec3605-ARM32-1:
+    ciscoiosxec3650-ARM32-1:
       pe_dir: 
       pe_ver: 
       pe_upgrade_dir: 
       pe_upgrade_ver: 
-      platform: cisco_iosxec3605-arm32
+      platform: cisco_iosxec3650-arm32
       ssh:
         user: admin
       hypervisor: vmpooler


### PR DESCRIPTION
This commit fixes the name of the Cisco c3650 device from 3605. Without this change there is no hostgenerator data for c3650.