### PR TITLE
(PE-26509) Add support for pe_compiler role

### DIFF
--- a/lib/beaker-hostgenerator/roles.rb
+++ b/lib/beaker-hostgenerator/roles.rb
@@ -11,13 +11,15 @@ module BeakerHostGenerator
       'm' => 'master',
     }
 
+    CM_CONFIG = { 'main' => {
+                    'dns_alt_names' => 'puppet',
+                    'environmentpath' => '/etc/puppetlabs/puppet/environments',
+                  }
+                }
+
     ROLE_CONFIG = {
-      'compile_master' => {
-        'main' => {
-          'dns_alt_names' => 'puppet',
-          'environmentpath' => '/etc/puppetlabs/puppet/environments',
-        }
-      }
+      'compile_master' => CM_CONFIG,
+      'pe_compiler' => CM_CONFIG,
     }
 
     module_function


### PR DESCRIPTION
This adds support for the new 'pe_compiler' role, which is a compile master with PuppetDB, by including the existing compile_master configuration when pe_compiler is specified.

Should be merged with https://github.com/puppetlabs/beaker-pe/pull/144 and https://github.com/puppetlabs/beaker-pe-large-environments/pull/30.