### PR TITLE
Add docker_image_commands to debian10 with docker

### DIFF
--- a/lib/beaker-hostgenerator/data.rb
+++ b/lib/beaker-hostgenerator/data.rb
@@ -458,6 +458,13 @@ module BeakerHostGenerator
             'platform'           => 'debian-10-amd64',
             'packaging_platform' => 'debian-10-amd64'
           },
+          :docker => {
+            'docker_image_commands' => [
+              'cp /bin/true /sbin/agetty',
+              'rm -f /usr/sbin/policy-rc.d',
+              'apt-get update && apt-get install -y cron locales-all net-tools wget gnupg'
+            ]
+          },
           :vmpooler => {
             'template' => 'debian-10-x86_64'
           }
@@ -466,6 +473,13 @@ module BeakerHostGenerator
           :general => {
             'platform'           => 'debian-10-i386',
             'packaging_platform' => 'debian-10-i386'
+          },
+          :docker => {
+            'docker_image_commands' => [
+              'cp /bin/true /sbin/agetty',
+              'rm -f /usr/sbin/policy-rc.d',
+              'apt-get update && apt-get install -y cron locales-all net-tools wget gnupg'
+            ]
           },
           :vmpooler => {
             'template' => 'debian-10-i386'


### PR DESCRIPTION
For the moment it looks to be impossible to run acceptance with Beaker on Debian10 and Docker :
https://travis-ci.org/voxpupuli/puppet-letsencrypt/jobs/564849203#L1208

The command `wget` used to get the `puppet-agent` is not present.
This PR add a section `docker_image_commands` to Debian10.

I removed `systemd-sysv` i suppose it is not useful now.