### PR TITLE
(MAINT) Add locale to vmpooler Jap/French defs

### DIFF
--- a/lib/beaker-hostgenerator/data.rb
+++ b/lib/beaker-hostgenerator/data.rb
@@ -1446,7 +1446,8 @@ module BeakerHostGenerator
             'ruby_arch' => 'x64'
           },
           :vmpooler => {
-            'template' => 'win-2012r2-ja-x86_64'
+            'template' => 'win-2012r2-ja-x86_64',
+            'locale'   => 'ja'
           }
         },
         'windows2012r2_ja-6432' => {
@@ -1456,7 +1457,8 @@ module BeakerHostGenerator
             'ruby_arch' => 'x86'
           },
           :vmpooler => {
-            'template' => 'win-2012r2-ja-x86_64'
+            'template' => 'win-2012r2-ja-x86_64',
+            'locale'   => 'ja'
           }
         },
         'windows2012r2_fr-64' => {
@@ -1467,7 +1469,8 @@ module BeakerHostGenerator
           },
           :vmpooler => {
             'template' => 'win-2012r2-fr-x86_64',
-            'user'     => 'Administrateur'
+            'user'     => 'Administrateur',
+            'locale'   => 'fr'
           }
         },
         'windows2012r2_fr-6432' => {
@@ -1478,7 +1481,8 @@ module BeakerHostGenerator
           },
           :vmpooler => {
             'template' => 'win-2012r2-fr-x86_64',
-            'user'     => 'Administrateur'
+            'user'     => 'Administrateur',
+            'locale'   => 'fr'
           }
         },
         'windows2012r2_core-64' => {
@@ -1549,7 +1553,8 @@ module BeakerHostGenerator
           },
           :vmpooler => {
             'template' => 'win-2016-fr-x86_64',
-            'user'     => 'Administrateur'
+            'user'     => 'Administrateur',
+            'locale'   => 'fr'
           }
         },
         'windows2016_fr-6432' => {
@@ -1560,7 +1565,8 @@ module BeakerHostGenerator
           },
           :vmpooler => {
             'template' => 'win-2016-fr-x86_64',
-            'user'     => 'Administrateur'
+            'user'     => 'Administrateur',
+            'locale'   => 'fr'
           }
         },
         'windows2019-64' => {
@@ -1590,7 +1596,8 @@ module BeakerHostGenerator
             'ruby_arch' => 'x64'
           },
           :vmpooler => {
-            'template' => 'win-2019-ja-x86_64'
+            'template' => 'win-2019-ja-x86_64',
+            'locale'   => 'ja'
           }
         },
         'windows2019_ja-6432' => {
@@ -1600,7 +1607,8 @@ module BeakerHostGenerator
             'ruby_arch' => 'x86'
           },
           :vmpooler => {
-            'template' => 'win-2019-ja-x86_64'
+            'template' => 'win-2019-ja-x86_64',
+            'locale'   => 'ja'
           }
         },
         'windows2019_fr-64' => {
@@ -1611,7 +1619,8 @@ module BeakerHostGenerator
           },
           :vmpooler => {
             'template' => 'win-2019-fr-x86_64',
-            'user'     => 'Administrateur'
+            'user'     => 'Administrateur',
+            'locale'   => 'fr'
           }
         },
         'windows2019_fr-6432' => {
@@ -1622,7 +1631,8 @@ module BeakerHostGenerator
           },
           :vmpooler => {
             'template' => 'win-2019-fr-x86_64',
-            'user'     => 'Administrateur'
+            'user'     => 'Administrateur',
+            'locale'   => 'fr'
           }
         },
         'windows2019_core-64' => {

--- a/test/fixtures/generated/default/windows2012r2_ja-6432l
+++ b/test/fixtures/generated/default/windows2012r2_ja-6432l
@@ -13,6 +13,7 @@ expected_hash:
       packaging_platform: windows-2012-x64
       ruby_arch: x86
       template: win-2012r2-ja-x86_64
+      locale: ja
       roles:
       - agent
       - classifier

--- a/test/fixtures/generated/default/windows2012r2_ja-64u
+++ b/test/fixtures/generated/default/windows2012r2_ja-64u
@@ -13,6 +13,7 @@ expected_hash:
       packaging_platform: windows-2012-x64
       ruby_arch: x64
       template: win-2012r2-ja-x86_64
+      locale: ja
       roles:
       - agent
       - ca

--- a/test/fixtures/generated/default/windows2016_fr-6432f
+++ b/test/fixtures/generated/default/windows2016_fr-6432f
@@ -14,6 +14,7 @@ expected_hash:
       template: win-2016-fr-x86_64
       user: Administrateur
       hypervisor: vmpooler
+      locale: fr
       roles:
       - agent
       - frictionless

--- a/test/fixtures/generated/default/windows2016_fr-64d
+++ b/test/fixtures/generated/default/windows2016_fr-64d
@@ -14,6 +14,7 @@ expected_hash:
       template: win-2016-fr-x86_64
       user: Administrateur
       hypervisor: vmpooler
+      locale: fr
       roles:
       - agent
       - database

--- a/test/fixtures/generated/default/windows2019_fr-6432f
+++ b/test/fixtures/generated/default/windows2019_fr-6432f
@@ -14,6 +14,7 @@ expected_hash:
       ruby_arch: x86
       template: win-2019-fr-x86_64
       user: Administrateur
+      locale: fr
       roles:
       - agent
       - frictionless

--- a/test/fixtures/generated/default/windows2019_fr-64c
+++ b/test/fixtures/generated/default/windows2019_fr-64c
@@ -14,6 +14,7 @@ expected_hash:
       ruby_arch: x64
       template: win-2019-fr-x86_64
       user: Administrateur
+      locale: fr
       roles:
       - agent
       - dashboard

--- a/test/fixtures/generated/default/windows2019_ja-6432f
+++ b/test/fixtures/generated/default/windows2019_ja-6432f
@@ -13,6 +13,7 @@ expected_hash:
       packaging_platform: windows-2012-x64
       ruby_arch: x86
       template: win-2019-ja-x86_64
+      locale: ja
       roles:
       - agent
       - frictionless

--- a/test/fixtures/generated/default/windows2019_ja-64c
+++ b/test/fixtures/generated/default/windows2019_ja-64c
@@ -13,6 +13,7 @@ expected_hash:
       packaging_platform: windows-2012-x64
       ruby_arch: x64
       template: win-2019-ja-x86_64
+      locale: ja
       roles:
       - agent
       - dashboard

--- a/test/fixtures/generated/multiplatform/centos5-64c-windows2016_fr-6432-centos5-64d
+++ b/test/fixtures/generated/multiplatform/centos5-64c-windows2016_fr-6432-centos5-64d
@@ -26,6 +26,7 @@ expected_hash:
       template: win-2016-fr-x86_64
       user: Administrateur
       hypervisor: vmpooler
+      locale: fr
       roles:
       - agent
     centos5-64-2:

--- a/test/fixtures/generated/multiplatform/centos6-32d-windows2016_fr-64-centos6-32c
+++ b/test/fixtures/generated/multiplatform/centos6-32d-windows2016_fr-64-centos6-32c
@@ -26,6 +26,7 @@ expected_hash:
       template: win-2016-fr-x86_64
       user: Administrateur
       hypervisor: vmpooler
+      locale: fr
       roles:
       - agent
     centos6-32-2:

--- a/test/fixtures/generated/multiplatform/centos6-32u-windows2012r2_ja-6432-centos6-32m
+++ b/test/fixtures/generated/multiplatform/centos6-32u-windows2012r2_ja-6432-centos6-32m
@@ -25,6 +25,7 @@ expected_hash:
       packaging_platform: windows-2012-x64
       ruby_arch: x86
       template: win-2012r2-ja-x86_64
+      locale: ja
       roles:
       - agent
     centos6-32-2:

--- a/test/fixtures/generated/multiplatform/centos6-64l-windows2012r2_ja-64-centos6-64f
+++ b/test/fixtures/generated/multiplatform/centos6-64l-windows2012r2_ja-64-centos6-64f
@@ -25,6 +25,7 @@ expected_hash:
       packaging_platform: windows-2012-x64
       ruby_arch: x64
       template: win-2012r2-ja-x86_64
+      locale: ja
       roles:
       - agent
     centos6-64-2:

--- a/test/fixtures/generated/multiplatform/ciscoiosc4507r-ARM32c-windows2012r2_fr-6432-ciscoiosc4507r-ARM32d
+++ b/test/fixtures/generated/multiplatform/ciscoiosc4507r-ARM32c-windows2012r2_fr-6432-ciscoiosc4507r-ARM32d
@@ -26,6 +26,7 @@ expected_hash:
       template: win-2012r2-fr-x86_64
       user: Administrateur
       hypervisor: vmpooler
+      locale: fr
       roles:
       - agent
     ciscoiosc4507r-ARM32-2:

--- a/test/fixtures/generated/multiplatform/ciscoiosc4948-ARM32d-windows2012r2_fr-64-ciscoiosc4948-ARM32c
+++ b/test/fixtures/generated/multiplatform/ciscoiosc4948-ARM32d-windows2012r2_fr-64-ciscoiosc4948-ARM32c
@@ -26,6 +26,7 @@ expected_hash:
       template: win-2012r2-fr-x86_64
       user: Administrateur
       hypervisor: vmpooler
+      locale: fr
       roles:
       - agent
     ciscoiosc4948-ARM32-2:

--- a/test/fixtures/generated/multiplatform/ciscoiosc6503-ARM32f-windows2012r2_ja-6432-ciscoiosc6503-ARM32l
+++ b/test/fixtures/generated/multiplatform/ciscoiosc6503-ARM32f-windows2012r2_ja-6432-ciscoiosc6503-ARM32l
@@ -25,6 +25,7 @@ expected_hash:
       ruby_arch: x86
       template: win-2012r2-ja-x86_64
       hypervisor: vmpooler
+      locale: ja
       roles:
       - agent
     ciscoiosc6503-ARM32-2:

--- a/test/fixtures/generated/multiplatform/ciscoiosxec3650-ARM32m-windows2012r2_ja-64-ciscoiosxec3650-ARM32u
+++ b/test/fixtures/generated/multiplatform/ciscoiosxec3650-ARM32m-windows2012r2_ja-64-ciscoiosxec3650-ARM32u
@@ -25,6 +25,7 @@ expected_hash:
       ruby_arch: x64
       template: win-2012r2-ja-x86_64
       hypervisor: vmpooler
+      locale: ja
       roles:
       - agent
     ciscoiosxec3650-ARM32-2:

--- a/test/fixtures/generated/multiplatform/windows2012r2_ja-6432l-centos6-32-windows2012r2_ja-6432f
+++ b/test/fixtures/generated/multiplatform/windows2012r2_ja-6432l-centos6-32-windows2012r2_ja-6432f
@@ -13,6 +13,7 @@ expected_hash:
       packaging_platform: windows-2012-x64
       ruby_arch: x86
       template: win-2012r2-ja-x86_64
+      locale: ja
       roles:
       - agent
       - classifier
@@ -37,6 +38,7 @@ expected_hash:
       packaging_platform: windows-2012-x64
       ruby_arch: x86
       template: win-2012r2-ja-x86_64
+      locale: ja
       roles:
       - agent
       - frictionless

--- a/test/fixtures/generated/multiplatform/windows2012r2_ja-64u-centos6-64-windows2012r2_ja-64m
+++ b/test/fixtures/generated/multiplatform/windows2012r2_ja-64u-centos6-64-windows2012r2_ja-64m
@@ -13,6 +13,7 @@ expected_hash:
       packaging_platform: windows-2012-x64
       ruby_arch: x64
       template: win-2012r2-ja-x86_64
+      locale: ja
       roles:
       - agent
       - ca
@@ -37,6 +38,7 @@ expected_hash:
       packaging_platform: windows-2012-x64
       ruby_arch: x64
       template: win-2012r2-ja-x86_64
+      locale: ja
       roles:
       - agent
       - master

--- a/test/fixtures/generated/multiplatform/windows2016_fr-6432f-centos5-64-windows2016_fr-6432l
+++ b/test/fixtures/generated/multiplatform/windows2016_fr-6432f-centos5-64-windows2016_fr-6432l
@@ -14,6 +14,7 @@ expected_hash:
       template: win-2016-fr-x86_64
       user: Administrateur
       hypervisor: vmpooler
+      locale: fr
       roles:
       - agent
       - frictionless
@@ -39,6 +40,7 @@ expected_hash:
       template: win-2016-fr-x86_64
       user: Administrateur
       hypervisor: vmpooler
+      locale: fr
       roles:
       - agent
       - classifier

--- a/test/fixtures/generated/multiplatform/windows2016_fr-64d-centos6-32-windows2016_fr-64c
+++ b/test/fixtures/generated/multiplatform/windows2016_fr-64d-centos6-32-windows2016_fr-64c
@@ -14,6 +14,7 @@ expected_hash:
       template: win-2016-fr-x86_64
       user: Administrateur
       hypervisor: vmpooler
+      locale: fr
       roles:
       - agent
       - database
@@ -39,6 +40,7 @@ expected_hash:
       template: win-2016-fr-x86_64
       user: Administrateur
       hypervisor: vmpooler
+      locale: fr
       roles:
       - agent
       - dashboard

--- a/test/fixtures/generated/osinfo-version-0/windows2012r2_ja-6432l
+++ b/test/fixtures/generated/osinfo-version-0/windows2012r2_ja-6432l
@@ -13,6 +13,7 @@ expected_hash:
       packaging_platform: windows-2012-x64
       ruby_arch: x86
       template: win-2012r2-ja-x86_64
+      locale: ja
       roles:
       - agent
       - classifier

--- a/test/fixtures/generated/osinfo-version-0/windows2012r2_ja-64u
+++ b/test/fixtures/generated/osinfo-version-0/windows2012r2_ja-64u
@@ -13,6 +13,7 @@ expected_hash:
       packaging_platform: windows-2012-x64
       ruby_arch: x64
       template: win-2012r2-ja-x86_64
+      locale: ja
       roles:
       - agent
       - ca

--- a/test/fixtures/generated/osinfo-version-0/windows2016_fr-6432f
+++ b/test/fixtures/generated/osinfo-version-0/windows2016_fr-6432f
@@ -14,6 +14,7 @@ expected_hash:
       template: win-2016-fr-x86_64
       user: Administrateur
       hypervisor: vmpooler
+      locale: fr
       roles:
       - agent
       - frictionless

--- a/test/fixtures/generated/osinfo-version-0/windows2016_fr-64d
+++ b/test/fixtures/generated/osinfo-version-0/windows2016_fr-64d
@@ -14,6 +14,7 @@ expected_hash:
       template: win-2016-fr-x86_64
       user: Administrateur
       hypervisor: vmpooler
+      locale: fr
       roles:
       - agent
       - database

--- a/test/fixtures/generated/osinfo-version-1/windows2012r2_ja-6432l
+++ b/test/fixtures/generated/osinfo-version-1/windows2012r2_ja-6432l
@@ -13,6 +13,7 @@ expected_hash:
       packaging_platform: windows-2012-x64
       ruby_arch: x86
       template: win-2012r2-ja-x86_64
+      locale: ja
       roles:
       - agent
       - classifier

--- a/test/fixtures/generated/osinfo-version-1/windows2012r2_ja-64u
+++ b/test/fixtures/generated/osinfo-version-1/windows2012r2_ja-64u
@@ -13,6 +13,7 @@ expected_hash:
       packaging_platform: windows-2012-x64
       ruby_arch: x64
       template: win-2012r2-ja-x86_64
+      locale: ja
       roles:
       - agent
       - ca

--- a/test/fixtures/generated/osinfo-version-1/windows2016_fr-6432f
+++ b/test/fixtures/generated/osinfo-version-1/windows2016_fr-6432f
@@ -14,6 +14,7 @@ expected_hash:
       template: win-2016-fr-x86_64
       user: Administrateur
       hypervisor: vmpooler
+      locale: fr
       roles:
       - agent
       - frictionless

--- a/test/fixtures/generated/osinfo-version-1/windows2016_fr-64d
+++ b/test/fixtures/generated/osinfo-version-1/windows2016_fr-64d
@@ -14,6 +14,7 @@ expected_hash:
       template: win-2016-fr-x86_64
       user: Administrateur
       hypervisor: vmpooler
+      locale: fr
       roles:
       - agent
       - database


### PR DESCRIPTION
This is an outcome of moving the Windows-2012r2 localised vmpooler platforms to Windows 2019. When trying to test the new BHG strings in the ci-job-configs repo using the Puppet Repo Jenkins test harness it was obvious that there were issues with the parsing of the embedded "locale" string in the BHG name.

So since BHG already supports additional Beaker variables in the definition (see the use of the "user" variable for the French platform definitions to allow Windows use a localised Administrator name) it
makes sense to properly embed the "locale" definition here for the French and Japanese platforms.

This will allow the removal of the  windows2019_ja-64%7Blocale=ja%7D type string from the Puppet Agent CI job definitions.