### PR TITLE
(QENG-7199) add cisco-n7k to data

### DIFF
--- a/lib/beaker-hostgenerator/data.rb
+++ b/lib/beaker-hostgenerator/data.rb
@@ -239,6 +239,19 @@ module BeakerHostGenerator
             'template' => 'cisco-nxos-9k-x86_64'
           }
         },
+        'ciscon7k-64' => {
+          :general => {
+            'platform'           => 'cisco_nexus-7k-x86_64',
+            'packaging_platform' => 'cisco-wrlinux-5-x86_64',
+            'vrf' => 'management',
+            'ssh' => {
+              'user' => 'admin'
+            }
+          },
+          :abs => {
+            'template' => 'cisco-n7k-7k-x86_64'
+          }
+        },
         'cisconxhw-64' => {
           :general => {
             'platform'           => 'cisco_nexus-7-x86_64',

--- a/test/fixtures/generated/default/ciscon7k-64a
+++ b/test/fixtures/generated/default/ciscon7k-64a
@@ -1,0 +1,23 @@
+---
+arguments_string: ciscon7k-64a
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    ciscon7k-64-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      platform: cisco_nexus-7k-x86_64
+      packaging_platform: cisco-wrlinux-5-x86_64
+      vrf: management
+      ssh:
+        user: admin
+      hypervisor: vmpooler
+      roles:
+      - agent
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception: 

--- a/test/fixtures/generated/multiplatform/ciscon7k-64a-windows2019-6432-ciscon7k-64aulcdfm
+++ b/test/fixtures/generated/multiplatform/ciscon7k-64a-windows2019-6432-ciscon7k-64aulcdfm
@@ -1,0 +1,54 @@
+---
+arguments_string: ciscon7k-64a-windows2019-6432-ciscon7k-64aulcdfm
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    ciscon7k-64-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      platform: cisco_nexus-7k-x86_64
+      packaging_platform: cisco-wrlinux-5-x86_64
+      vrf: management
+      ssh:
+        user: admin
+      hypervisor: vmpooler
+      roles:
+      - agent
+    windows2019-6432-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      platform: windows-2019-64
+      packaging_platform: windows-2012-x64
+      ruby_arch: x86
+      template: win-2019-x86_64
+      hypervisor: vmpooler
+      roles:
+      - agent
+    ciscon7k-64-2:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      platform: cisco_nexus-7k-x86_64
+      packaging_platform: cisco-wrlinux-5-x86_64
+      vrf: management
+      ssh:
+        user: admin
+      hypervisor: vmpooler
+      roles:
+      - agent
+      - ca
+      - classifier
+      - dashboard
+      - database
+      - frictionless
+      - master
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception: 

--- a/test/fixtures/generated/osinfo-version-0/ciscon7k-64a
+++ b/test/fixtures/generated/osinfo-version-0/ciscon7k-64a
@@ -1,0 +1,23 @@
+---
+arguments_string: "--osinfo-version 0 ciscon7k-64a"
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    ciscon7k-64-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      platform: cisco_nexus-7k-x86_64
+      packaging_platform: cisco-wrlinux-5-x86_64
+      vrf: management
+      ssh:
+        user: admin
+      hypervisor: vmpooler
+      roles:
+      - agent
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception: 

--- a/test/fixtures/generated/osinfo-version-1/ciscon7k-64a
+++ b/test/fixtures/generated/osinfo-version-1/ciscon7k-64a
@@ -1,0 +1,23 @@
+---
+arguments_string: "--osinfo-version 1 ciscon7k-64a"
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    ciscon7k-64-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      platform: cisco_nexus-7k-x86_64
+      packaging_platform: cisco-wrlinux-5-x86_64
+      vrf: management
+      ssh:
+        user: admin
+      hypervisor: vmpooler
+      roles:
+      - agent
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception: 


### PR DESCRIPTION
tried to run the test generation rake task to update tests, but got a ton of what seems like extra stuff.

For instance, these are some of the files created:
```
	test/fixtures/generated/osinfo-version-1/ubuntu1810-64aulcdfm
	test/fixtures/generated/osinfo-version-1/vro6-64a
	test/fixtures/generated/osinfo-version-1/vro7-64u
	test/fixtures/generated/osinfo-version-1/vro71-64l
	test/fixtures/generated/osinfo-version-1/vro73-64c
	test/fixtures/generated/osinfo-version-1/vro74-64d
	test/fixtures/generated/osinfo-version-1/windows10_1511-64u
	test/fixtures/generated/osinfo-version-1/windows10_1607-64l
	test/fixtures/generated/osinfo-version-1/windows10_1809-64c
```

@smcelmurry I assume I'm just missing something silly, or executing this wrong?