### PR TITLE
(PE-27037) Use redhatfips-7-x86_64 for fips platform

### DIFF
--- a/lib/beaker-hostgenerator/data.rb
+++ b/lib/beaker-hostgenerator/data.rb
@@ -882,7 +882,7 @@ module BeakerHostGenerator
         },
         'redhatfips7-64' => {
           :general => {
-            'platform'           => 'el-7-x86_64',
+            'platform'           => 'redhatfips-7-x86_64',
             'packaging_platform' => 'redhatfips-7-x86_64'
           },
           :vmpooler => {

--- a/test/fixtures/generated/default/redhatfips7-64aulcdfm
+++ b/test/fixtures/generated/default/redhatfips7-64aulcdfm
@@ -9,7 +9,7 @@ expected_hash:
       pe_upgrade_dir: 
       pe_upgrade_ver: 
       hypervisor: vmpooler
-      platform: el-7-x86_64
+      platform: redhatfips-7-x86_64
       packaging_platform: redhatfips-7-x86_64
       template: redhat-fips-7-x86_64
       roles:

--- a/test/fixtures/generated/multiplatform/redhatfips7-64aulcdfm-sles10-32-redhatfips7-64a
+++ b/test/fixtures/generated/multiplatform/redhatfips7-64aulcdfm-sles10-32-redhatfips7-64a
@@ -9,7 +9,7 @@ expected_hash:
       pe_upgrade_dir: 
       pe_upgrade_ver: 
       hypervisor: vmpooler
-      platform: el-7-x86_64
+      platform: redhatfips-7-x86_64
       packaging_platform: redhatfips-7-x86_64
       template: redhat-fips-7-x86_64
       roles:
@@ -36,7 +36,7 @@ expected_hash:
       pe_upgrade_dir: 
       pe_upgrade_ver: 
       hypervisor: vmpooler
-      platform: el-7-x86_64
+      platform: redhatfips-7-x86_64
       packaging_platform: redhatfips-7-x86_64
       template: redhat-fips-7-x86_64
       roles:

--- a/test/fixtures/generated/multiplatform/sles10-32a-redhatfips7-64-sles10-32aulcdfm
+++ b/test/fixtures/generated/multiplatform/sles10-32a-redhatfips7-64-sles10-32aulcdfm
@@ -19,7 +19,7 @@ expected_hash:
       pe_upgrade_dir: 
       pe_upgrade_ver: 
       hypervisor: vmpooler
-      platform: el-7-x86_64
+      platform: redhatfips-7-x86_64
       packaging_platform: redhatfips-7-x86_64
       template: redhat-fips-7-x86_64
       roles:

--- a/test/fixtures/generated/osinfo-version-0/redhatfips7-64aulcdfm
+++ b/test/fixtures/generated/osinfo-version-0/redhatfips7-64aulcdfm
@@ -9,7 +9,7 @@ expected_hash:
       pe_upgrade_dir: 
       pe_upgrade_ver: 
       hypervisor: vmpooler
-      platform: el-7-x86_64
+      platform: redhatfips-7-x86_64
       packaging_platform: redhatfips-7-x86_64
       template: redhat-fips-7-x86_64
       roles:

--- a/test/fixtures/generated/osinfo-version-1/redhatfips7-64aulcdfm
+++ b/test/fixtures/generated/osinfo-version-1/redhatfips7-64aulcdfm
@@ -9,7 +9,7 @@ expected_hash:
       pe_upgrade_dir: 
       pe_upgrade_ver: 
       hypervisor: vmpooler
-      platform: el-7-x86_64
+      platform: redhatfips-7-x86_64
       packaging_platform: redhatfips-7-x86_64
       template: redhat-fips-7-x86_64
       roles:


### PR DESCRIPTION
Now that we have a redhatfips7 tarball, this changes hostgenerator to use the redhatfips-7-x86_64 platform rather than el-7-x86_64.