### PR TITLE
(MAINT) remove markdown requirement

### DIFF
--- a/beaker-hostgenerator.gemspec
+++ b/beaker-hostgenerator.gemspec
@@ -30,7 +30,6 @@ eos
 
   # Documentation dependencies
   s.add_development_dependency 'yard'
-  s.add_development_dependency 'markdown'
   s.add_development_dependency 'thin'
 
   # Run time dependencies


### PR DESCRIPTION
The markdown down gem requires activesupport, which in
the newest version (6), loses support for Rubies below
2.5. There's no need for the markdown gem, so we'll
remove it rather than be forced to push up Ruby versions
at this time.

Ref: https://github.com/puppetlabs/beaker-puppet/pull/124