### PR TITLE
(RE-12859) Migrate from enterprise.delivery.puppetlabs.net to Artifactory

### DIFF
--- a/lib/beaker-hostgenerator/data.rb
+++ b/lib/beaker-hostgenerator/data.rb
@@ -14,7 +14,7 @@ module BeakerHostGenerator
   module Data
     module_function
 
-    PE_TARBALL_SERVER="http://enterprise.delivery.puppetlabs.net"
+    PE_TARBALL_SERVER="https://artifactory.delivery.puppetlabs.net/artifactory/generic_enterprise__local"
 
     def pe_version
       ENV['pe_version']

--- a/test/fixtures/generated/environment_variable_tests/pe_version_and_pe_family/centos6-32a
+++ b/test/fixtures/generated/environment_variable_tests/pe_version_and_pe_family/centos6-32a
@@ -8,9 +8,9 @@ environment_variables:
 expected_hash:
   HOSTS:
     centos6-32-1:
-      pe_dir: http://enterprise.delivery.puppetlabs.net/archives/releases/6.6.6/
+      pe_dir: https://artifactory.delivery.puppetlabs.net/artifactory/generic_enterprise__local/archives/releases/6.6.6/
       pe_ver: 6.6.6
-      pe_upgrade_dir: http://enterprise.delivery.puppetlabs.net/archives/releases/6.6.6/
+      pe_upgrade_dir: https://artifactory.delivery.puppetlabs.net/artifactory/generic_enterprise__local/archives/releases/6.6.6/
       pe_upgrade_ver: 6.6.6
       hypervisor: vmpooler
       platform: el-6-i386

--- a/test/fixtures/generated/environment_variable_tests/pe_version_and_pe_family_no_upgrade/centos6-32a
+++ b/test/fixtures/generated/environment_variable_tests/pe_version_and_pe_family_no_upgrade/centos6-32a
@@ -6,7 +6,7 @@ environment_variables:
 expected_hash:
   HOSTS:
     centos6-32-1:
-      pe_dir: http://enterprise.delivery.puppetlabs.net/archives/releases/6.6.6/
+      pe_dir: https://artifactory.delivery.puppetlabs.net/artifactory/generic_enterprise__local/archives/releases/6.6.6/
       pe_ver: 6.6.6
       pe_upgrade_dir: 
       pe_upgrade_ver: 

--- a/test/fixtures/generated/environment_variable_tests/pe_version_and_pe_family_upgrade_only/centos6-32a
+++ b/test/fixtures/generated/environment_variable_tests/pe_version_and_pe_family_upgrade_only/centos6-32a
@@ -8,7 +8,7 @@ expected_hash:
     centos6-32-1:
       pe_dir: 
       pe_ver: 
-      pe_upgrade_dir: http://enterprise.delivery.puppetlabs.net/archives/releases/6.6.6/
+      pe_upgrade_dir: https://artifactory.delivery.puppetlabs.net/artifactory/generic_enterprise__local/archives/releases/6.6.6/
       pe_upgrade_ver: 6.6.6
       hypervisor: vmpooler
       platform: el-6-i386


### PR DESCRIPTION
This commit replaces usage of enterprise.delivery.puppetlabs.net (aka saturn)
with Artifactory so that we can ultimately decommission it.