### PR TITLE
(maint) fix cisco-9k/cisco-n9k typo

### DIFF
--- a/lib/beaker-hostgenerator/data.rb
+++ b/lib/beaker-hostgenerator/data.rb
@@ -332,7 +332,7 @@ module BeakerHostGenerator
             }
           },
           :abs => {
-            'template' => 'cisco-9k-x86_64'
+            'template' => 'cisco-n9k-x86_64'
           }
         },
         'cisco_ios_c2960-HW' => {


### PR DESCRIPTION
```
david@davids:~/git/beaker-hostgenerator$ curl -H "X-AUTH-TOKEN: $(vmpooler_token)" -s -X GET --url https://nspooler-service-prod-1.delivery.puppetlabs.net/api/v1/status/ | jq . | grep cisco-n9k
  "cisco-n9k-x86_64": {
david@davids:~/git/beaker-hostgenerator$
```