### PR TITLE
(PE-27608) Master branch PEZ logic

### DIFF
--- a/lib/beaker-hostgenerator/data.rb
+++ b/lib/beaker-hostgenerator/data.rb
@@ -13,7 +13,7 @@ module BeakerHostGenerator
   # `include BeakerHostGenerator::Data` and then `<function>()`.
   module Data
     module_function
-
+    MASTER_PE_VERSION=2019.4
     PE_TARBALL_SERVER="https://artifactory.delivery.puppetlabs.net/artifactory/generic_enterprise__local"
 
     def pe_version
@@ -41,7 +41,16 @@ module BeakerHostGenerator
         ''
       end
 
-      pe_branch = Gem::Version.new($1) < Gem::Version.new('2019.4') || version =~ /#{base_regex}-rc\d+\Z/ ? $1 : 'master'
+      if(Gem::Version.new($1) < Gem::Version.new("#{MASTER_PE_VERSION}") || version =~ /#{base_regex}-rc\d+\Z/)
+        pe_branch = $1
+      else
+        #Is this a Master PEZ build?
+        if(version =~ /.*(PEZ|pez)_.*/)
+          pe_branch = "master/feature"
+        else
+          pe_branch = 'master'
+        end
+      end
 
       return sprintf(source, ("#{pe_branch}" || ''))
     end

--- a/spec/beaker-hostgenerator/generator_spec.rb
+++ b/spec/beaker-hostgenerator/generator_spec.rb
@@ -147,7 +147,7 @@ module BeakerHostGenerator
       end
 
       it "returns master/feature/ci-ready for a PEZ version" do
-        expect(BeakerHostGenerator::Data.pe_dir(pez_version)).to match(%r{master/feature/ci-ready})
+        expect(BeakerHostGenerator::Data.pe_dir(pez_version)).to match('master/feature')
       end
     end
   end


### PR DESCRIPTION
In order for PEZ builds to be located correctly we need to add in some
logic. This PR adds to the Master branch logic by looking at the tarball
string and seeing if it is a PEZ tarball. If so point the pe_dir to the
feature directory, where the PEZ tarballs are put.