### PR TITLE
Use debian/buster64 for Vagrant

### DIFF
--- a/lib/beaker-hostgenerator/data.rb
+++ b/lib/beaker-hostgenerator/data.rb
@@ -571,6 +571,9 @@ module BeakerHostGenerator
               'apt-get update && apt-get install -y cron locales-all net-tools wget gnupg'
             ]
           },
+          :vagrant => {
+            'box' => 'debian/buster64',
+          },
           :vmpooler => {
             'template' => 'debian-10-x86_64'
           }


### PR DESCRIPTION
This switches from generic/debian10 to debian/buster64. This is the official box and thus closer to what should be expected by end users.