### PR TITLE
(maint) Update PE master version

### DIFF
--- a/lib/beaker-hostgenerator/data.rb
+++ b/lib/beaker-hostgenerator/data.rb
@@ -13,7 +13,7 @@ module BeakerHostGenerator
   # `include BeakerHostGenerator::Data` and then `<function>()`.
   module Data
     module_function
-    MASTER_PE_VERSION=2019.4
+    MASTER_PE_VERSION=2019.5
     PE_TARBALL_SERVER="https://artifactory.delivery.puppetlabs.net/artifactory/generic_enterprise__local"
 
     def pe_version

--- a/spec/beaker-hostgenerator/generator_spec.rb
+++ b/spec/beaker-hostgenerator/generator_spec.rb
@@ -89,7 +89,7 @@ module BeakerHostGenerator
       end
     end
 
-    context "pe_dir for versions < 2019.4" do
+    context "pe_dir for versions < 2019.5" do
       let(:dev_version) { '2017.3.0-rc4-11-g123abcd' }
       let(:dev_version_no_rc) { '2017.3.0-1-g123abcd' }
       let(:pez_version) { '2017.3.0-rc4-11-g123abcd-PEZ_foo' }
@@ -126,12 +126,12 @@ module BeakerHostGenerator
       end
     end
 
-    context "pe_dir for versions >= 2019.4" do
-      let(:dev_version) { '2019.4.0-rc4-11-g123abcd' }
-      let(:dev_version_no_rc) { '2019.4.0-1-g123abcd' }
-      let(:pez_version) { '2019.4.0-rc4-11-g123abcd-PEZ_foo' }
-      let(:release_version) { '2019.4.0' }
-      let(:rc_version) { '2019.4.0-rc4' }
+    context "pe_dir for versions >= 2019.5" do
+      let(:dev_version) { '2019.5.0-rc4-11-g123abcd' }
+      let(:dev_version_no_rc) { '2019.5.0-1-g123abcd' }
+      let(:pez_version) { '2019.5.0-rc4-11-g123abcd-PEZ_foo' }
+      let(:release_version) { '2019.5.0' }
+      let(:rc_version) { '2019.5.0-rc4' }
 
       it "returns master/ci-ready for a dev version" do
         expect(BeakerHostGenerator::Data.pe_dir(dev_version)).to match(%r{master/ci-ready})
@@ -139,11 +139,11 @@ module BeakerHostGenerator
       end
 
       it "returns archives/releases/<version> for a release version" do
-        expect(BeakerHostGenerator::Data.pe_dir(release_version)).to match(%r{archives/releases/2019\.4\.0})
+        expect(BeakerHostGenerator::Data.pe_dir(release_version)).to match(%r{archives/releases/2019\.5\.0})
       end
 
       it "returns archives/internal/master for an rc version" do
-        expect(BeakerHostGenerator::Data.pe_dir(rc_version)).to match(%r{archives/internal/2019.4})
+        expect(BeakerHostGenerator::Data.pe_dir(rc_version)).to match(%r{archives/internal/2019.5})
       end
 
       it "returns master/feature/ci-ready for a PEZ version" do


### PR DESCRIPTION
Required to keep some internal PE testing from breaking. 