### PR TITLE
install apt-transport-https on debian 8 and debian 9

### DIFF
--- a/lib/beaker-hostgenerator/data.rb
+++ b/lib/beaker-hostgenerator/data.rb
@@ -514,7 +514,7 @@ module BeakerHostGenerator
             'docker_image_commands' => [
               'cp /bin/true /sbin/agetty',
               'rm -f /usr/sbin/policy-rc.d',
-              'apt-get update && apt-get install -y cron locales-all net-tools wget'
+              'apt-get update && apt-get install -y cron locales-all net-tools wget apt-transport-https'
             ]
           },
           :vagrant => {
@@ -536,7 +536,7 @@ module BeakerHostGenerator
             'docker_image_commands' => [
               'cp /bin/true /sbin/agetty',
               'rm -f /usr/sbin/policy-rc.d',
-              'apt-get update && apt-get install -y cron locales-all net-tools wget'
+              'apt-get update && apt-get install -y cron locales-all net-tools wget apt-transport-https'
             ]
           }
         },
@@ -549,7 +549,7 @@ module BeakerHostGenerator
             'docker_image_commands' => [
               'cp /bin/true /sbin/agetty',
               'rm -f /usr/sbin/policy-rc.d',
-              'apt-get update && apt-get install -y cron locales-all net-tools wget systemd-sysv gnupg'
+              'apt-get update && apt-get install -y cron locales-all net-tools wget systemd-sysv gnupg apt-transport-https'
             ]
           },
           :vagrant => {


### PR DESCRIPTION
The package `apt-transport-https` does not look present on old docker images.

We have debian8 and debian9 jobs that are failing with message: `The method driver /usr/lib/apt/methods/https could not be found.`

Details :
https://github.com/voxpupuli/puppet-nodejs/pull/416
