### PR TITLE
Install glibc-langpack-en on CentOS 8

### DIFF
--- a/lib/beaker-hostgenerator/data.rb
+++ b/lib/beaker-hostgenerator/data.rb
@@ -246,7 +246,7 @@ module BeakerHostGenerator
           :docker => {
             'docker_image_commands' => [
               'cp /bin/true /sbin/agetty',
-              'yum install -y crontabs initscripts iproute openssl wget which'
+              'yum install -y crontabs initscripts iproute openssl wget which glibc-langpack-en'
             ]
           },
           :vmpooler => {


### PR DESCRIPTION
This ensures the en_US.UTF-8 locale is present which is very commonly used. This doesn't go as far as the Debian images, which install locales-all.