### PR TITLE
Add Fedora 32 + fix Fedora Vagrant box name

### DIFF
--- a/lib/beaker-hostgenerator/data.rb
+++ b/lib/beaker-hostgenerator/data.rb
@@ -772,6 +772,15 @@ module BeakerHostGenerator
             'template' => 'fedora-31-x86_64'
           }
         },
+        'fedora32-64' => {
+          :general => {
+            'platform'           => 'fedora-32-x86_64',
+            'packaging_platform' => 'fedora-32-x86_64'
+          },
+          :vmpooler => {
+            'template' => 'fedora-32-x86_64'
+          }
+        },
         'huaweios6-POWER' => {
           :general => {
             'platform' => 'huaweios-6-powerpc'

--- a/lib/beaker-hostgenerator/hypervisor/vagrant.rb
+++ b/lib/beaker-hostgenerator/hypervisor/vagrant.rb
@@ -11,7 +11,7 @@ module BeakerHostGenerator
         if node_info['ostype'] =~ /^centos/
           base_config['box'] = node_info['ostype'].sub(/(\d)/, '/\1')
         elsif node_info['ostype'] =~ /^fedora/
-          base_config['box'] = node_info['ostype'].sub(/(\d)/, '/\1') + 'cloud-base'
+          base_config['box'] = node_info['ostype'].sub(/(\d)/, '/\1') + '-cloud-base'
         else
           base_config['box'] = "generic/#{node_info['ostype']}"
         end

--- a/test/fixtures/generated/default/fedora32-64aulcdfm-vagrant
+++ b/test/fixtures/generated/default/fedora32-64aulcdfm-vagrant
@@ -1,0 +1,27 @@
+---
+arguments_string: fedora32-64aulcdfm{hypervisor=vagrant}
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    fedora32-64-1:
+      pe_dir: 
+      pe_ver: 
+      pe_upgrade_dir: 
+      pe_upgrade_ver: 
+      box: fedora/32-cloud-base
+      synced_folder: disabled
+      platform: fedora-32-x86_64
+      packaging_platform: fedora-32-x86_64
+      hypervisor: vagrant
+      roles:
+      - agent
+      - ca
+      - classifier
+      - dashboard
+      - database
+      - frictionless
+      - master
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+expected_exception:


### PR DESCRIPTION
Previously it genereated fedora/31cloud-base but this needs to be 
fedora/31-cloud-base.