### PR TITLE
(IMAGES-1230) Add support for RedHat 8 ARM64

### DIFF
--- a/lib/beaker-hostgenerator/data.rb
+++ b/lib/beaker-hostgenerator/data.rb
@@ -1048,6 +1048,18 @@ module BeakerHostGenerator
             'template' => 'redhat-8-x86_64'
           }
         },
+        'redhat8-AARCH64' => {
+          :general => {
+            'platform'           => 'el-8-aarch64',
+            'packaging_platform' => 'el-8-aarch64'
+          },
+          :abs => {
+            'template' => 'redhat-8-arm64'
+          },
+          :vmpooler => {
+            'template' => 'redhat-8-x86_64'
+          }
+        },
         'scientific5-32' => {
           :general => {
             'platform'           => 'el-5-i386',

--- a/test/fixtures/generated/default/redhat8-AARCH64a
+++ b/test/fixtures/generated/default/redhat8-AARCH64a
@@ -1,0 +1,21 @@
+---
+arguments_string: redhat8-AARCH64a
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    redhat8-AARCH64-1:
+      pe_dir:
+      pe_ver:
+      pe_upgrade_dir:
+      pe_upgrade_ver:
+      platform: el-8-aarch64
+      packaging_platform: el-8-aarch64
+      template: redhat-8-x86_64
+      hypervisor: vmpooler
+      roles:
+      - agent
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception:

--- a/test/fixtures/generated/multiplatform/redhat6-64a-redhat8-AARCH64-redhat6-64aulcdfm
+++ b/test/fixtures/generated/multiplatform/redhat6-64a-redhat8-AARCH64-redhat6-64aulcdfm
@@ -1,0 +1,49 @@
+---
+arguments_string: redhat6-64a-redhat8-AARCH64-redhat6-64aulcdfm
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    redhat6-64-1:
+      pe_dir:
+      pe_ver:
+      pe_upgrade_dir:
+      pe_upgrade_ver:
+      platform: el-6-x86_64
+      packaging_platform: el-6-x86_64
+      template: redhat-6-x86_64
+      hypervisor: vmpooler
+      roles:
+      - agent
+    redhat8-AARCH64-1:
+      pe_dir:
+      pe_ver:
+      pe_upgrade_dir:
+      pe_upgrade_ver:
+      platform: el-8-aarch64
+      packaging_platform: el-8-aarch64
+      template: redhat-8-x86_64
+      hypervisor: vmpooler
+      roles:
+      - agent
+    redhat6-64-2:
+      pe_dir:
+      pe_ver:
+      pe_upgrade_dir:
+      pe_upgrade_ver:
+      platform: el-6-x86_64
+      packaging_platform: el-6-x86_64
+      template: redhat-6-x86_64
+      hypervisor: vmpooler
+      roles:
+      - agent
+      - ca
+      - classifier
+      - dashboard
+      - database
+      - frictionless
+      - master
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception:

--- a/test/fixtures/generated/multiplatform/redhat8-AARCH64a-redhat6-64-redhat8-AARCH64aulcdfm
+++ b/test/fixtures/generated/multiplatform/redhat8-AARCH64a-redhat6-64-redhat8-AARCH64aulcdfm
@@ -1,0 +1,49 @@
+---
+arguments_string: redhat8-AARCH64a-redhat6-64-redhat8-AARCH64aulcdfm
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    redhat8-AARCH64-1:
+      pe_dir:
+      pe_ver:
+      pe_upgrade_dir:
+      pe_upgrade_ver:
+      platform: el-8-aarch64
+      packaging_platform: el-8-aarch64
+      template: redhat-8-x86_64
+      hypervisor: vmpooler
+      roles:
+      - agent
+    redhat6-64-1:
+      pe_dir:
+      pe_ver:
+      pe_upgrade_dir:
+      pe_upgrade_ver:
+      platform: el-6-x86_64
+      packaging_platform: el-6-x86_64
+      template: redhat-6-x86_64
+      hypervisor: vmpooler
+      roles:
+      - agent
+    redhat8-AARCH64-2:
+      pe_dir:
+      pe_ver:
+      pe_upgrade_dir:
+      pe_upgrade_ver:
+      platform: el-8-aarch64
+      packaging_platform: el-8-aarch64
+      template: redhat-8-x86_64
+      hypervisor: vmpooler
+      roles:
+      - agent
+      - ca
+      - classifier
+      - dashboard
+      - database
+      - frictionless
+      - master
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-0/redhat8-AARCH64a
+++ b/test/fixtures/generated/osinfo-version-0/redhat8-AARCH64a
@@ -1,0 +1,21 @@
+---
+arguments_string: "--osinfo-version 0 redhat8-AARCH64a"
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    redhat8-AARCH64-1:
+      pe_dir:
+      pe_ver:
+      pe_upgrade_dir:
+      pe_upgrade_ver:
+      platform: el-8-aarch64
+      packaging_platform: el-8-aarch64
+      template: redhat-8-x86_64
+      hypervisor: vmpooler
+      roles:
+      - agent
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception:

--- a/test/fixtures/generated/osinfo-version-1/redhat8-AARCH64a
+++ b/test/fixtures/generated/osinfo-version-1/redhat8-AARCH64a
@@ -1,0 +1,21 @@
+---
+arguments_string: "--osinfo-version 1 redhat8-AARCH64a"
+environment_variables: {}
+expected_hash:
+  HOSTS:
+    redhat8-AARCH64-1:
+      pe_dir:
+      pe_ver:
+      pe_upgrade_dir:
+      pe_upgrade_ver:
+      platform: el-8-aarch64
+      packaging_platform: el-8-aarch64
+      template: redhat-8-x86_64
+      hypervisor: vmpooler
+      roles:
+      - agent
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+    pooling_api: http://vmpooler.delivery.puppetlabs.net/
+expected_exception:


### PR DESCRIPTION
The arm64 and aarch64 targets are interchangeable, so I followed the
example of redhat7. Set the vmpooler template to x86_64 as we're going
to cross-compile packages.