### PR TITLE
Generate Fedora and CentOS data where possible

### DIFF
--- a/lib/beaker-hostgenerator/data.rb
+++ b/lib/beaker-hostgenerator/data.rb
@@ -92,7 +92,27 @@ module BeakerHostGenerator
     # Hypervisor implementations will then grab specific bits of data out of
     # this hash and combine them to produce the generated hosts output.
     def osinfo
-      {
+      result = {}
+
+      # Fedora
+      (19..32).each do |release|
+        # 32 bit support was dropped in Fedora 31
+        if release < 31
+          result["fedora#{release}-32"] = {
+            :general => {
+              'platform' => "fedora-#{release}-i386"
+            }
+          }
+        end
+
+        result["fedora#{release}-64"] = {
+          :general => {
+            'platform' => "fedora-#{release}-x86_64"
+          }
+        }
+      end
+
+      result.merge!({
         'aix53-POWER' => {
           :general => {
             'platform'           => 'aix-5.3-power',
@@ -606,188 +626,6 @@ module BeakerHostGenerator
         'fedora14-32' => {
           :general => {
             'platform' => 'fedora-14-i386'
-          },
-          :vmpooler => {
-            'template' => 'fedora-14-i386'
-          }
-        },
-        'fedora19-32' => {
-          :general => {
-            'platform' => 'fedora-19-i386'
-          },
-          :vmpooler => {
-            'template' => 'fedora-19-i386'
-          }
-        },
-        'fedora19-64' => {
-          :general => {
-            'platform' => 'fedora-19-x86_64'
-          },
-          :vmpooler => {
-            'template' => 'fedora-19-x86_64'
-          }
-        },
-        'fedora20-32' => {
-          :general => {
-            'platform' => 'fedora-20-i386'
-          },
-          :vmpooler => {
-            'template' => 'fedora-20-i386'
-          }
-        },
-        'fedora20-64' => {
-          :general => {
-            'platform' => 'fedora-20-x86_64'
-          },
-          :vmpooler => {
-            'template' => 'fedora-20-x86_64'
-          }
-        },
-        'fedora21-32' => {
-          :general => {
-            'platform' => 'fedora-21-i386'
-          },
-          :vmpooler => {
-            'template' => 'fedora-21-i386'
-          }
-        },
-        'fedora21-64' => {
-          :general => {
-            'platform' => 'fedora-21-x86_64'
-          },
-          :vmpooler => {
-            'template' => 'fedora-21-x86_64'
-          }
-        },
-        'fedora22-32' => {
-          :general => {
-            'platform' => 'fedora-22-i386'
-          },
-          :vmpooler => {
-            'template' => 'fedora-22-i386'
-          }
-        },
-        'fedora22-64' => {
-          :general => {
-            'platform' => 'fedora-22-x86_64'
-          },
-          :vmpooler => {
-            'template' => 'fedora-22-x86_64'
-          }
-        },
-        'fedora23-32' => {
-          :general => {
-            'platform' => 'fedora-23-i386'
-          },
-          :vmpooler => {
-            'template' => 'fedora-23-i386'
-          }
-        },
-        'fedora23-64' => {
-          :general => {
-            'platform' => 'fedora-23-x86_64'
-          },
-          :vmpooler => {
-            'template' => 'fedora-23-x86_64'
-          }
-        },
-        'fedora24-32' => {
-          :general => {
-            'platform'           => 'fedora-24-i386',
-            'packaging_platform' => 'fedora-24-i386'
-          },
-          :vmpooler => {
-            'template' => 'fedora-24-i386'
-          }
-        },
-        'fedora24-64' => {
-          :general => {
-            'platform'           => 'fedora-24-x86_64',
-            'packaging_platform' => 'fedora-24-x86_64'
-          },
-          :vmpooler => {
-            'template' => 'fedora-24-x86_64'
-          }
-        },
-        'fedora25-32' => {
-          :general => {
-            'platform'           => 'fedora-25-i386',
-            'packaging_platform' => 'fedora-25-i386'
-          },
-          :vmpooler => {
-            'template' => 'fedora-25-i386'
-          }
-        },
-        'fedora25-64' => {
-          :general => {
-            'platform'           => 'fedora-25-x86_64',
-            'packaging_platform' => 'fedora-25-x86_64'
-          },
-          :vmpooler => {
-            'template' => 'fedora-25-x86_64'
-          }
-        },
-        'fedora26-64' => {
-          :general => {
-            'platform'           => 'fedora-26-x86_64',
-            'packaging_platform' => 'fedora-26-x86_64'
-          },
-          :vmpooler => {
-            'template' => 'fedora-26-x86_64'
-          }
-        },
-        'fedora27-64' => {
-          :general => {
-            'platform'           => 'fedora-27-x86_64',
-            'packaging_platform' => 'fedora-27-x86_64'
-          },
-          :vmpooler => {
-            'template' => 'fedora-27-x86_64'
-          }
-        },
-        'fedora28-64' => {
-          :general => {
-            'platform'           => 'fedora-28-x86_64',
-            'packaging_platform' => 'fedora-28-x86_64'
-          },
-          :vmpooler => {
-            'template' => 'fedora-28-x86_64'
-          }
-        },
-        'fedora29-64' => {
-          :general => {
-            'platform'           => 'fedora-29-x86_64',
-            'packaging_platform' => 'fedora-29-x86_64'
-          },
-          :vmpooler => {
-            'template' => 'fedora-29-x86_64'
-          }
-        },
-        'fedora30-64' => {
-          :general => {
-            'platform'           => 'fedora-30-x86_64',
-            'packaging_platform' => 'fedora-30-x86_64'
-          },
-          :vmpooler => {
-            'template' => 'fedora-30-x86_64'
-          }
-        },
-        'fedora31-64' => {
-          :general => {
-            'platform'           => 'fedora-31-x86_64',
-            'packaging_platform' => 'fedora-31-x86_64'
-          },
-          :vmpooler => {
-            'template' => 'fedora-31-x86_64'
-          }
-        },
-        'fedora32-64' => {
-          :general => {
-            'platform'           => 'fedora-32-x86_64',
-            'packaging_platform' => 'fedora-32-x86_64'
-          },
-          :vmpooler => {
-            'template' => 'fedora-32-x86_64'
           }
         },
         'huaweios6-POWER' => {
@@ -1949,7 +1787,9 @@ module BeakerHostGenerator
             'template' => 'win-10-1809-x86_64'
           }
         }
-      }
+      })
+
+      result
     end
 
     def osinfo_bhgv1

--- a/lib/beaker-hostgenerator/data.rb
+++ b/lib/beaker-hostgenerator/data.rb
@@ -188,26 +188,17 @@ module BeakerHostGenerator
         'centos4-32' => {
           :general => {
             'platform' => 'el-4-i386'
-          },
-          :vmpooler => {
-            'template' => 'centos-4-i386'
           }
         },
         'centos4-64' => {
           :general => {
             'platform' => 'el-4-x86_64'
-          },
-          :vmpooler => {
-            'template' => 'centos-4-x86_64'
           }
         },
         'centos5-32' => {
           :general => {
             'platform'           => 'el-5-i386',
             'packaging_platform' => 'el-5-i386'
-          },
-          :vmpooler => {
-            'template' => 'centos-5-i386'
           }
         },
         'centos5-64' => {
@@ -221,18 +212,12 @@ module BeakerHostGenerator
               'yum install -y crontabs initscripts iproute openssl sysvinit-tools tar wget which',
               'sed -i -e "/mingetty/d" /etc/inittab'
             ]
-          },
-          :vmpooler => {
-            'template' => 'centos-5-x86_64'
           }
         },
         'centos6-32' => {
           :general => {
             'platform'           => 'el-6-i386',
             'packaging_platform' => 'el-6-i386'
-          },
-          :vmpooler => {
-            'template' => 'centos-6-i386'
           }
         },
         'centos6-64' => {
@@ -247,9 +232,6 @@ module BeakerHostGenerator
               'yum install -y crontabs initscripts iproute openssl sysvinit-tools tar wget which',
               'rm /etc/init/tty.conf'
             ]
-          },
-          :vmpooler => {
-            'template' => 'centos-6-x86_64'
           }
         },
         'centos7-64' => {
@@ -262,9 +244,6 @@ module BeakerHostGenerator
               'cp /bin/true /sbin/agetty',
               'yum install -y crontabs initscripts iproute openssl sysvinit-tools tar wget which ss'
             ]
-          },
-          :vmpooler => {
-            'template' => 'centos-7-x86_64'
           }
         },
         'centos8-64' => {
@@ -277,9 +256,6 @@ module BeakerHostGenerator
               'cp /bin/true /sbin/agetty',
               'yum install -y crontabs initscripts iproute openssl wget which glibc-langpack-en'
             ]
-          },
-          :vmpooler => {
-            'template' => 'centos-8-x86_64'
           }
         },
         # Deprecated

--- a/lib/beaker-hostgenerator/hypervisor/abs.rb
+++ b/lib/beaker-hostgenerator/hypervisor/abs.rb
@@ -23,6 +23,8 @@ module BeakerHostGenerator
         base_config = base_generate_node(node_info, base_config, bhg_version, :vmpooler, :abs)
 
         case node_info['ostype']
+        when /^centos/
+          base_config['template'] = base_config['platform'].gsub(/^el/, 'centos')
         when /^fedora/
           base_config['template'] = base_config['platform']
         end

--- a/lib/beaker-hostgenerator/hypervisor/abs.rb
+++ b/lib/beaker-hostgenerator/hypervisor/abs.rb
@@ -20,7 +20,14 @@ module BeakerHostGenerator
         # any given platform will have *either* :vmpooler data or :abs data
         # so we're not worried about one overriding the other when we merge
         # the hashes together.
-        return base_generate_node(node_info, base_config, bhg_version, :vmpooler, :abs)
+        base_config = base_generate_node(node_info, base_config, bhg_version, :vmpooler, :abs)
+
+        case node_info['ostype']
+        when /^fedora/
+          base_config['template'] = base_config['platform']
+        end
+
+        base_config
       end
     end
   end

--- a/lib/beaker-hostgenerator/hypervisor/vmpooler.rb
+++ b/lib/beaker-hostgenerator/hypervisor/vmpooler.rb
@@ -18,6 +18,8 @@ module BeakerHostGenerator
         base_config = base_generate_node(node_info, base_config, bhg_version, :vmpooler)
 
         case node_info['ostype']
+        when /^centos/
+          base_config['template'] = base_config['platform'].gsub(/^el/, 'centos')
         when /^fedora/
           base_config['template'] = base_config['platform']
         end

--- a/lib/beaker-hostgenerator/hypervisor/vmpooler.rb
+++ b/lib/beaker-hostgenerator/hypervisor/vmpooler.rb
@@ -17,6 +17,11 @@ module BeakerHostGenerator
       def generate_node(node_info, base_config, bhg_version)
         base_config = base_generate_node(node_info, base_config, bhg_version, :vmpooler)
 
+        case node_info['ostype']
+        when /^fedora/
+          base_config['template'] = base_config['platform']
+        end
+
         # Some vmpooler/vsphere platforms have special requirements.
         # We munge the node host config here if that is necessary.
         fixup_node base_config

--- a/test/fixtures/generated/default/fedora24-32l
+++ b/test/fixtures/generated/default/fedora24-32l
@@ -10,7 +10,6 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: fedora-24-i386
-      packaging_platform: fedora-24-i386
       template: fedora-24-i386
       roles:
       - agent

--- a/test/fixtures/generated/default/fedora24-64c
+++ b/test/fixtures/generated/default/fedora24-64c
@@ -10,7 +10,6 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: fedora-24-x86_64
-      packaging_platform: fedora-24-x86_64
       template: fedora-24-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/default/fedora25-32d
+++ b/test/fixtures/generated/default/fedora25-32d
@@ -10,7 +10,6 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: fedora-25-i386
-      packaging_platform: fedora-25-i386
       template: fedora-25-i386
       roles:
       - agent

--- a/test/fixtures/generated/default/fedora25-64f
+++ b/test/fixtures/generated/default/fedora25-64f
@@ -10,7 +10,6 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: fedora-25-x86_64
-      packaging_platform: fedora-25-x86_64
       template: fedora-25-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/default/fedora26-64m
+++ b/test/fixtures/generated/default/fedora26-64m
@@ -10,7 +10,6 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: fedora-26-x86_64
-      packaging_platform: fedora-26-x86_64
       template: fedora-26-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/default/fedora27-64l
+++ b/test/fixtures/generated/default/fedora27-64l
@@ -10,7 +10,6 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: fedora-27-x86_64
-      packaging_platform: fedora-27-x86_64
       template: fedora-27-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/default/fedora28-64d
+++ b/test/fixtures/generated/default/fedora28-64d
@@ -10,7 +10,6 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: fedora-28-x86_64
-      packaging_platform: fedora-28-x86_64
       template: fedora-28-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/default/fedora29-64d
+++ b/test/fixtures/generated/default/fedora29-64d
@@ -10,7 +10,6 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: fedora-29-x86_64
-      packaging_platform: fedora-29-x86_64
       template: fedora-29-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/default/fedora30-64aulcdfm
+++ b/test/fixtures/generated/default/fedora30-64aulcdfm
@@ -9,7 +9,6 @@ expected_hash:
       pe_upgrade_dir: 
       pe_upgrade_ver: 
       platform: fedora-30-x86_64
-      packaging_platform: fedora-30-x86_64
       template: fedora-30-x86_64
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/default/fedora31-64aulcdfm
+++ b/test/fixtures/generated/default/fedora31-64aulcdfm
@@ -9,7 +9,6 @@ expected_hash:
       pe_upgrade_dir: 
       pe_upgrade_ver: 
       platform: fedora-31-x86_64
-      packaging_platform: fedora-31-x86_64
       template: fedora-31-x86_64
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/default/fedora32-64a
+++ b/test/fixtures/generated/default/fedora32-64a
@@ -9,7 +9,6 @@ expected_hash:
       pe_upgrade_dir: 
       pe_upgrade_ver: 
       platform: fedora-32-x86_64
-      packaging_platform: fedora-32-x86_64
       template: fedora-32-x86_64
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/default/fedora32-64aulcdfm-vagrant
+++ b/test/fixtures/generated/default/fedora32-64aulcdfm-vagrant
@@ -11,7 +11,6 @@ expected_hash:
       box: fedora/32-cloud-base
       synced_folder: disabled
       platform: fedora-32-x86_64
-      packaging_platform: fedora-32-x86_64
       hypervisor: vagrant
       roles:
       - agent

--- a/test/fixtures/generated/multiplatform/fedora24-32l-ubuntu1504-64-fedora24-32f
+++ b/test/fixtures/generated/multiplatform/fedora24-32l-ubuntu1504-64-fedora24-32f
@@ -10,7 +10,6 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: fedora-24-i386
-      packaging_platform: fedora-24-i386
       template: fedora-24-i386
       roles:
       - agent
@@ -32,7 +31,6 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: fedora-24-i386
-      packaging_platform: fedora-24-i386
       template: fedora-24-i386
       roles:
       - agent

--- a/test/fixtures/generated/multiplatform/fedora24-64c-ubuntu1504-32-fedora24-64d
+++ b/test/fixtures/generated/multiplatform/fedora24-64c-ubuntu1504-32-fedora24-64d
@@ -10,7 +10,6 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: fedora-24-x86_64
-      packaging_platform: fedora-24-x86_64
       template: fedora-24-x86_64
       roles:
       - agent
@@ -32,7 +31,6 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: fedora-24-x86_64
-      packaging_platform: fedora-24-x86_64
       template: fedora-24-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/multiplatform/fedora25-32d-ubuntu1404-64-fedora25-32c
+++ b/test/fixtures/generated/multiplatform/fedora25-32d-ubuntu1404-64-fedora25-32c
@@ -10,7 +10,6 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: fedora-25-i386
-      packaging_platform: fedora-25-i386
       template: fedora-25-i386
       roles:
       - agent
@@ -33,7 +32,6 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: fedora-25-i386
-      packaging_platform: fedora-25-i386
       template: fedora-25-i386
       roles:
       - agent

--- a/test/fixtures/generated/multiplatform/fedora25-64f-ubuntu1404-32-fedora25-64l
+++ b/test/fixtures/generated/multiplatform/fedora25-64f-ubuntu1404-32-fedora25-64l
@@ -10,7 +10,6 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: fedora-25-x86_64
-      packaging_platform: fedora-25-x86_64
       template: fedora-25-x86_64
       roles:
       - agent
@@ -33,7 +32,6 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: fedora-25-x86_64
-      packaging_platform: fedora-25-x86_64
       template: fedora-25-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/multiplatform/fedora26-64m-ubuntu1204-64-fedora26-64u
+++ b/test/fixtures/generated/multiplatform/fedora26-64m-ubuntu1204-64-fedora26-64u
@@ -10,7 +10,6 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: fedora-26-x86_64
-      packaging_platform: fedora-26-x86_64
       template: fedora-26-x86_64
       roles:
       - agent
@@ -32,7 +31,6 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: fedora-26-x86_64
-      packaging_platform: fedora-26-x86_64
       template: fedora-26-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/multiplatform/fedora27-64l-ubuntu1404-64-fedora27-64f
+++ b/test/fixtures/generated/multiplatform/fedora27-64l-ubuntu1404-64-fedora27-64f
@@ -10,7 +10,6 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: fedora-27-x86_64
-      packaging_platform: fedora-27-x86_64
       template: fedora-27-x86_64
       roles:
       - agent
@@ -33,7 +32,6 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: fedora-27-x86_64
-      packaging_platform: fedora-27-x86_64
       template: fedora-27-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/multiplatform/fedora28-64d-ubuntu1404-64-fedora28-64c
+++ b/test/fixtures/generated/multiplatform/fedora28-64d-ubuntu1404-64-fedora28-64c
@@ -10,7 +10,6 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: fedora-28-x86_64
-      packaging_platform: fedora-28-x86_64
       template: fedora-28-x86_64
       roles:
       - agent
@@ -33,7 +32,6 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: fedora-28-x86_64
-      packaging_platform: fedora-28-x86_64
       template: fedora-28-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/multiplatform/fedora29-64d-ubuntu1604-POWER-fedora29-64c
+++ b/test/fixtures/generated/multiplatform/fedora29-64d-ubuntu1604-POWER-fedora29-64c
@@ -10,7 +10,6 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: fedora-29-x86_64
-      packaging_platform: fedora-29-x86_64
       template: fedora-29-x86_64
       roles:
       - agent
@@ -32,7 +31,6 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: fedora-29-x86_64
-      packaging_platform: fedora-29-x86_64
       template: fedora-29-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/multiplatform/fedora30-64aulcdfm-ubuntu1204-64-fedora30-64a
+++ b/test/fixtures/generated/multiplatform/fedora30-64aulcdfm-ubuntu1204-64-fedora30-64a
@@ -9,7 +9,6 @@ expected_hash:
       pe_upgrade_dir: 
       pe_upgrade_ver: 
       platform: fedora-30-x86_64
-      packaging_platform: fedora-30-x86_64
       template: fedora-30-x86_64
       hypervisor: vmpooler
       roles:
@@ -36,7 +35,6 @@ expected_hash:
       pe_upgrade_dir: 
       pe_upgrade_ver: 
       platform: fedora-30-x86_64
-      packaging_platform: fedora-30-x86_64
       template: fedora-30-x86_64
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/multiplatform/fedora31-64aulcdfm-solaris114-64-fedora31-64a
+++ b/test/fixtures/generated/multiplatform/fedora31-64aulcdfm-solaris114-64-fedora31-64a
@@ -9,7 +9,6 @@ expected_hash:
       pe_upgrade_dir: 
       pe_upgrade_ver: 
       platform: fedora-31-x86_64
-      packaging_platform: fedora-31-x86_64
       template: fedora-31-x86_64
       hypervisor: vmpooler
       roles:
@@ -37,7 +36,6 @@ expected_hash:
       pe_upgrade_dir: 
       pe_upgrade_ver: 
       platform: fedora-31-x86_64
-      packaging_platform: fedora-31-x86_64
       template: fedora-31-x86_64
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/multiplatform/fedora32-64a-solaris114-64-fedora32-64aulcdfm
+++ b/test/fixtures/generated/multiplatform/fedora32-64a-solaris114-64-fedora32-64aulcdfm
@@ -9,7 +9,6 @@ expected_hash:
       pe_upgrade_dir: 
       pe_upgrade_ver: 
       platform: fedora-32-x86_64
-      packaging_platform: fedora-32-x86_64
       template: fedora-32-x86_64
       hypervisor: vmpooler
       roles:
@@ -31,7 +30,6 @@ expected_hash:
       pe_upgrade_dir: 
       pe_upgrade_ver: 
       platform: fedora-32-x86_64
-      packaging_platform: fedora-32-x86_64
       template: fedora-32-x86_64
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/multiplatform/solaris114-64aulcdfm-fedora32-64-solaris114-64a
+++ b/test/fixtures/generated/multiplatform/solaris114-64aulcdfm-fedora32-64-solaris114-64a
@@ -26,7 +26,6 @@ expected_hash:
       pe_upgrade_dir: 
       pe_upgrade_ver: 
       platform: fedora-32-x86_64
-      packaging_platform: fedora-32-x86_64
       template: fedora-32-x86_64
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/multiplatform/solaris114-64f-fedora31-64-solaris114-64l
+++ b/test/fixtures/generated/multiplatform/solaris114-64f-fedora31-64-solaris114-64l
@@ -21,7 +21,6 @@ expected_hash:
       pe_upgrade_dir: 
       pe_upgrade_ver: 
       platform: fedora-31-x86_64
-      packaging_platform: fedora-31-x86_64
       template: fedora-31-x86_64
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/multiplatform/ubuntu1204-64f-fedora26-64-ubuntu1204-64l
+++ b/test/fixtures/generated/multiplatform/ubuntu1204-64f-fedora26-64-ubuntu1204-64l
@@ -21,7 +21,6 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: fedora-26-x86_64
-      packaging_platform: fedora-26-x86_64
       template: fedora-26-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/multiplatform/ubuntu1204-64u-fedora30-64-ubuntu1204-64m
+++ b/test/fixtures/generated/multiplatform/ubuntu1204-64u-fedora30-64-ubuntu1204-64m
@@ -20,7 +20,6 @@ expected_hash:
       pe_upgrade_dir: 
       pe_upgrade_ver: 
       platform: fedora-30-x86_64
-      packaging_platform: fedora-30-x86_64
       template: fedora-30-x86_64
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/multiplatform/ubuntu1404-32m-fedora25-64-ubuntu1404-32u
+++ b/test/fixtures/generated/multiplatform/ubuntu1404-32m-fedora25-64-ubuntu1404-32u
@@ -22,7 +22,6 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: fedora-25-x86_64
-      packaging_platform: fedora-25-x86_64
       template: fedora-25-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/multiplatform/ubuntu1404-64a-fedora28-64-ubuntu1404-64aulcdfm
+++ b/test/fixtures/generated/multiplatform/ubuntu1404-64a-fedora28-64-ubuntu1404-64aulcdfm
@@ -21,7 +21,6 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: fedora-28-x86_64
-      packaging_platform: fedora-28-x86_64
       template: fedora-28-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/multiplatform/ubuntu1404-64aulcdfm-fedora25-32-ubuntu1404-64a
+++ b/test/fixtures/generated/multiplatform/ubuntu1404-64aulcdfm-fedora25-32-ubuntu1404-64a
@@ -27,7 +27,6 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: fedora-25-i386
-      packaging_platform: fedora-25-i386
       template: fedora-25-i386
       roles:
       - agent

--- a/test/fixtures/generated/multiplatform/ubuntu1404-64m-fedora27-64-ubuntu1404-64u
+++ b/test/fixtures/generated/multiplatform/ubuntu1404-64m-fedora27-64-ubuntu1404-64u
@@ -22,7 +22,6 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: fedora-27-x86_64
-      packaging_platform: fedora-27-x86_64
       template: fedora-27-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/multiplatform/ubuntu1504-32a-fedora24-64-ubuntu1504-32aulcdfm
+++ b/test/fixtures/generated/multiplatform/ubuntu1504-32a-fedora24-64-ubuntu1504-32aulcdfm
@@ -20,7 +20,6 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: fedora-24-x86_64
-      packaging_platform: fedora-24-x86_64
       template: fedora-24-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/multiplatform/ubuntu1504-64u-fedora24-32-ubuntu1504-64m
+++ b/test/fixtures/generated/multiplatform/ubuntu1504-64u-fedora24-32-ubuntu1504-64m
@@ -21,7 +21,6 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: fedora-24-i386
-      packaging_platform: fedora-24-i386
       template: fedora-24-i386
       roles:
       - agent

--- a/test/fixtures/generated/multiplatform/ubuntu1604-POWERf-fedora29-64-ubuntu1604-POWERl
+++ b/test/fixtures/generated/multiplatform/ubuntu1604-POWERf-fedora29-64-ubuntu1604-POWERl
@@ -21,7 +21,6 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: fedora-29-x86_64
-      packaging_platform: fedora-29-x86_64
       template: fedora-29-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/osinfo-version-0/fedora24-32l
+++ b/test/fixtures/generated/osinfo-version-0/fedora24-32l
@@ -10,7 +10,6 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: fedora-24-i386
-      packaging_platform: fedora-24-i386
       template: fedora-24-i386
       roles:
       - agent

--- a/test/fixtures/generated/osinfo-version-0/fedora24-64c
+++ b/test/fixtures/generated/osinfo-version-0/fedora24-64c
@@ -10,7 +10,6 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: fedora-24-x86_64
-      packaging_platform: fedora-24-x86_64
       template: fedora-24-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/osinfo-version-0/fedora25-32d
+++ b/test/fixtures/generated/osinfo-version-0/fedora25-32d
@@ -10,7 +10,6 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: fedora-25-i386
-      packaging_platform: fedora-25-i386
       template: fedora-25-i386
       roles:
       - agent

--- a/test/fixtures/generated/osinfo-version-0/fedora25-64f
+++ b/test/fixtures/generated/osinfo-version-0/fedora25-64f
@@ -10,7 +10,6 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: fedora-25-x86_64
-      packaging_platform: fedora-25-x86_64
       template: fedora-25-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/osinfo-version-0/fedora26-64m
+++ b/test/fixtures/generated/osinfo-version-0/fedora26-64m
@@ -10,7 +10,6 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: fedora-26-x86_64
-      packaging_platform: fedora-26-x86_64
       template: fedora-26-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/osinfo-version-0/fedora27-64l
+++ b/test/fixtures/generated/osinfo-version-0/fedora27-64l
@@ -10,7 +10,6 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: fedora-27-x86_64
-      packaging_platform: fedora-27-x86_64
       template: fedora-27-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/osinfo-version-0/fedora28-64d
+++ b/test/fixtures/generated/osinfo-version-0/fedora28-64d
@@ -10,7 +10,6 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: fedora-28-x86_64
-      packaging_platform: fedora-28-x86_64
       template: fedora-28-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/osinfo-version-0/fedora29-64d
+++ b/test/fixtures/generated/osinfo-version-0/fedora29-64d
@@ -10,7 +10,6 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: fedora-29-x86_64
-      packaging_platform: fedora-29-x86_64
       template: fedora-29-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/osinfo-version-0/fedora30-64aulcdfm
+++ b/test/fixtures/generated/osinfo-version-0/fedora30-64aulcdfm
@@ -9,7 +9,6 @@ expected_hash:
       pe_upgrade_dir: 
       pe_upgrade_ver: 
       platform: fedora-30-x86_64
-      packaging_platform: fedora-30-x86_64
       template: fedora-30-x86_64
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/osinfo-version-0/fedora31-64aulcdfm
+++ b/test/fixtures/generated/osinfo-version-0/fedora31-64aulcdfm
@@ -9,7 +9,6 @@ expected_hash:
       pe_upgrade_dir: 
       pe_upgrade_ver: 
       platform: fedora-31-x86_64
-      packaging_platform: fedora-31-x86_64
       template: fedora-31-x86_64
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/osinfo-version-0/fedora32-64a
+++ b/test/fixtures/generated/osinfo-version-0/fedora32-64a
@@ -9,7 +9,6 @@ expected_hash:
       pe_upgrade_dir: 
       pe_upgrade_ver: 
       platform: fedora-32-x86_64
-      packaging_platform: fedora-32-x86_64
       template: fedora-32-x86_64
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/osinfo-version-1/fedora24-32l
+++ b/test/fixtures/generated/osinfo-version-1/fedora24-32l
@@ -10,7 +10,6 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: fedora-24-i386
-      packaging_platform: fedora-24-i386
       template: fedora-24-i386
       roles:
       - agent

--- a/test/fixtures/generated/osinfo-version-1/fedora24-64c
+++ b/test/fixtures/generated/osinfo-version-1/fedora24-64c
@@ -10,7 +10,6 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: fedora-24-x86_64
-      packaging_platform: fedora-24-x86_64
       template: fedora-24-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/osinfo-version-1/fedora25-32d
+++ b/test/fixtures/generated/osinfo-version-1/fedora25-32d
@@ -10,7 +10,6 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: fedora-25-i386
-      packaging_platform: fedora-25-i386
       template: fedora-25-i386
       roles:
       - agent

--- a/test/fixtures/generated/osinfo-version-1/fedora25-64f
+++ b/test/fixtures/generated/osinfo-version-1/fedora25-64f
@@ -10,7 +10,6 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: fedora-25-x86_64
-      packaging_platform: fedora-25-x86_64
       template: fedora-25-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/osinfo-version-1/fedora26-64m
+++ b/test/fixtures/generated/osinfo-version-1/fedora26-64m
@@ -10,7 +10,6 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: fedora-26-x86_64
-      packaging_platform: fedora-26-x86_64
       template: fedora-26-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/osinfo-version-1/fedora27-64l
+++ b/test/fixtures/generated/osinfo-version-1/fedora27-64l
@@ -10,7 +10,6 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: fedora-27-x86_64
-      packaging_platform: fedora-27-x86_64
       template: fedora-27-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/osinfo-version-1/fedora28-64d
+++ b/test/fixtures/generated/osinfo-version-1/fedora28-64d
@@ -10,7 +10,6 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: fedora-28-x86_64
-      packaging_platform: fedora-28-x86_64
       template: fedora-28-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/osinfo-version-1/fedora29-64d
+++ b/test/fixtures/generated/osinfo-version-1/fedora29-64d
@@ -10,7 +10,6 @@ expected_hash:
       pe_upgrade_ver: 
       hypervisor: vmpooler
       platform: fedora-29-x86_64
-      packaging_platform: fedora-29-x86_64
       template: fedora-29-x86_64
       roles:
       - agent

--- a/test/fixtures/generated/osinfo-version-1/fedora30-64aulcdfm
+++ b/test/fixtures/generated/osinfo-version-1/fedora30-64aulcdfm
@@ -9,7 +9,6 @@ expected_hash:
       pe_upgrade_dir: 
       pe_upgrade_ver: 
       platform: fedora-30-x86_64
-      packaging_platform: fedora-30-x86_64
       template: fedora-30-x86_64
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/osinfo-version-1/fedora31-64aulcdfm
+++ b/test/fixtures/generated/osinfo-version-1/fedora31-64aulcdfm
@@ -9,7 +9,6 @@ expected_hash:
       pe_upgrade_dir: 
       pe_upgrade_ver: 
       platform: fedora-31-x86_64
-      packaging_platform: fedora-31-x86_64
       template: fedora-31-x86_64
       hypervisor: vmpooler
       roles:

--- a/test/fixtures/generated/osinfo-version-1/fedora32-64a
+++ b/test/fixtures/generated/osinfo-version-1/fedora32-64a
@@ -9,7 +9,6 @@ expected_hash:
       pe_upgrade_dir: 
       pe_upgrade_ver: 
       platform: fedora-32-x86_64
-      packaging_platform: fedora-32-x86_64
       template: fedora-32-x86_64
       hypervisor: vmpooler
       roles:


### PR DESCRIPTION
All Fedora definitions are the same, so they might as well be generated in a loop. packaging_platform is dropped since beaker defaults to platform. In the case of Fedora they always match.

For CentOS only the vmpooler templates are generated because the Docker image commands differ too much.