### PR TITLE
(maint) Update for removal of enterprise-dist master

### DIFF
--- a/lib/beaker-hostgenerator/data.rb
+++ b/lib/beaker-hostgenerator/data.rb
@@ -13,7 +13,6 @@ module BeakerHostGenerator
   # `include BeakerHostGenerator::Data` and then `<function>()`.
   module Data
     module_function
-    MASTER_PE_VERSION=2019.5
     MAIN_PE_VERSION=2021.0
     PE_TARBALL_SERVER="https://artifactory.delivery.puppetlabs.net/artifactory/generic_enterprise__local"
 
@@ -42,23 +41,12 @@ module BeakerHostGenerator
         ''
       end
 
-      gem_version = Gem::Version.new($1)
-      if(gem_version < Gem::Version.new("#{MASTER_PE_VERSION}") || version =~ /#{base_regex}-rc\d+\Z/)
-        pe_branch = $1
-      elsif gem_version < Gem::Version.new("#{MAIN_PE_VERSION}")
-        #Is this a Master PEZ build?
-        if(version =~ /.*(PEZ|pez)_.*/)
-          pe_branch = "master/feature"
-        else
-          pe_branch = 'master'
-        end
+      pe_family = $1
+      gem_version = Gem::Version.new(pe_family)
+      if(gem_version < Gem::Version.new("#{MAIN_PE_VERSION}") || version =~ /#{base_regex}-rc\d+\Z/)
+        pe_branch = pe_family
       else
-        #Is this a Main PEZ build?
-        if(version =~ /.*(PEZ|pez)_.*/)
-          pe_branch = "main/feature"
-        else
-          pe_branch = 'main'
-        end
+        pe_branch = 'main'
       end
 
       return sprintf(source, ("#{pe_branch}" || ''))

--- a/spec/beaker-hostgenerator/generator_spec.rb
+++ b/spec/beaker-hostgenerator/generator_spec.rb
@@ -89,28 +89,28 @@ module BeakerHostGenerator
       end
     end
 
-    context "pe_dir for versions < 2019.5" do
-      let(:dev_version) { '2017.3.0-rc4-11-g123abcd' }
-      let(:dev_version_no_rc) { '2017.3.0-1-g123abcd' }
-      let(:pez_version) { '2017.3.0-rc4-11-g123abcd-PEZ_foo' }
-      let(:release_version) { '2017.2.2' }
-      let(:rc_version) { '2017.3.0-rc4' }
+    context "pe_dir for versions < 2021.0" do
+      let(:dev_version) { '2019.8.0-rc4-11-g123abcd' }
+      let(:dev_version_no_rc) { '2019.8.0-1-g123abcd' }
+      let(:pez_version) { '2019.8.0-rc4-11-g123abcd-PEZ_foo' }
+      let(:release_version) { '2019.8.2' }
+      let(:rc_version) { '2019.8.0-rc4' }
 
       it "returns ci-ready for a dev version" do
-        expect(BeakerHostGenerator::Data.pe_dir(dev_version)).to match(%r{2017\.3/ci-ready})
-        expect(BeakerHostGenerator::Data.pe_dir(dev_version_no_rc)).to match(%r{2017\.3/ci-ready})
+        expect(BeakerHostGenerator::Data.pe_dir(dev_version)).to match(%r{2019\.8/ci-ready})
+        expect(BeakerHostGenerator::Data.pe_dir(dev_version_no_rc)).to match(%r{2019\.8/ci-ready})
       end
 
       it "returns archives/releases for a release version" do
-        expect(BeakerHostGenerator::Data.pe_dir(release_version)).to match(%r{archives/releases/2017\.2})
+        expect(BeakerHostGenerator::Data.pe_dir(release_version)).to match(%r{archives/releases/2019\.8})
       end
 
       it "returns archives/internal for an rc version" do
-        expect(BeakerHostGenerator::Data.pe_dir(rc_version)).to match(%r{archives/internal/2017\.3})
+        expect(BeakerHostGenerator::Data.pe_dir(rc_version)).to match(%r{archives/internal/2019\.8})
       end
 
       it "returns feature/ci-ready for a PEZ version" do
-        expect(BeakerHostGenerator::Data.pe_dir(pez_version)).to match(%r{2017\.3/feature/ci-ready})
+        expect(BeakerHostGenerator::Data.pe_dir(pez_version)).to match(%r{2019\.8/feature/ci-ready})
       end
 
       it "returns nil if version is nil" do
@@ -123,31 +123,6 @@ module BeakerHostGenerator
 
       it "returns an empty string if version isn't parseable" do
         expect(BeakerHostGenerator::Data.pe_dir('wtf')).to eq('')
-      end
-    end
-
-    context "pe_dir for versions >= 2019.5" do
-      let(:dev_version) { '2019.5.0-rc4-11-g123abcd' }
-      let(:dev_version_no_rc) { '2019.5.0-1-g123abcd' }
-      let(:pez_version) { '2019.5.0-rc4-11-g123abcd-PEZ_foo' }
-      let(:release_version) { '2019.5.0' }
-      let(:rc_version) { '2019.5.0-rc4' }
-
-      it "returns master/ci-ready for a dev version" do
-        expect(BeakerHostGenerator::Data.pe_dir(dev_version)).to match(%r{master/ci-ready})
-        expect(BeakerHostGenerator::Data.pe_dir(dev_version_no_rc)).to match(%r{master/ci-ready})
-      end
-
-      it "returns archives/releases/<version> for a release version" do
-        expect(BeakerHostGenerator::Data.pe_dir(release_version)).to match(%r{archives/releases/2019\.5\.0})
-      end
-
-      it "returns archives/internal/master for an rc version" do
-        expect(BeakerHostGenerator::Data.pe_dir(rc_version)).to match(%r{archives/internal/2019.5})
-      end
-
-      it "returns master/feature/ci-ready for a PEZ version" do
-        expect(BeakerHostGenerator::Data.pe_dir(pez_version)).to match('master/feature')
       end
     end
 


### PR DESCRIPTION
The master branch of enterprise-dist is now 2019.8.x, so the only thing we need to special-case is setting pe_dir for 2021 to 'main'.