### PR TITLE
(maint) Fix for PEZ builds

### DIFF
--- a/lib/beaker-hostgenerator/data.rb
+++ b/lib/beaker-hostgenerator/data.rb
@@ -33,7 +33,7 @@ module BeakerHostGenerator
         then "#{PE_TARBALL_SERVER}/archives/releases/#{version}/"
       when /#{base_regex}-rc\d+\Z/
         then "#{PE_TARBALL_SERVER}/archives/internal/%s/"
-      when /#{base_regex}-.*PEZ_.*/
+      when /#{base_regex}-.*(PEZ|pez)_.*/
         then "#{PE_TARBALL_SERVER}/%s/feature/ci-ready"
       when /#{base_regex}-.*/
         then "#{PE_TARBALL_SERVER}/%s/ci-ready"

--- a/spec/beaker-hostgenerator/generator_spec.rb
+++ b/spec/beaker-hostgenerator/generator_spec.rb
@@ -129,7 +129,7 @@ module BeakerHostGenerator
     context "pe_dir for versions >= 2021.0" do
       let(:dev_version) { '2021.0.0-rc4-11-g123abcd' }
       let(:dev_version_no_rc) { '2021.0.0-1-g123abcd' }
-      let(:pez_version) { '2021.0.0-rc4-11-g123abcd-PEZ_foo' }
+      let(:pez_version) { '2021.0.0-rc4-11-g123abcd-pez_foo' } # Some jobs use "PEZ" and some "pez"
       let(:release_version) { '2021.0.0' }
       let(:rc_version) { '2021.0.0-rc4' }
 


### PR DESCRIPTION
The previous commit omitted the case when the version contains 'pez' and not 'PEZ'.