### PR TITLE
Add Fedora 33 support

### DIFF
--- a/lib/beaker-hostgenerator/data.rb
+++ b/lib/beaker-hostgenerator/data.rb
@@ -83,7 +83,7 @@ module BeakerHostGenerator
       result = {}
 
       # Fedora
-      (19..32).each do |release|
+      (19..33).each do |release|
         # 32 bit support was dropped in Fedora 31
         if release < 31
           result["fedora#{release}-32"] = {


### PR DESCRIPTION
Even though no offical packages have been built by Puppet, it still makes sense to be able to generate a definition.