### PR TITLE
(maint) Remove existing codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,0 @@
-* @puppetlabs/beaker


### PR DESCRIPTION
This updates the existing codeowners file to be empty. We are planning
to transfer this repository to voxpupuli, and Codeowners files do not
currently support referencing teams from organizations that do not also
own the repo. That means that `@puppetlabs/beaker` will not reference
anything once we transfer the repo. Further, none of the members of that
team are actively working with this repo.